### PR TITLE
Add Alternator integration test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  IS_CICD: 1
+
 jobs:
   verify:
     name: Verify (Node ${{ matrix.node-version }})
@@ -37,6 +40,31 @@ jobs:
 
       - name: Verify package
         run: npm run verify
+
+      - name: Cache Docker image
+        id: docker-cache
+        uses: actions/cache@v5
+        with:
+          path: .docker-cache
+          key: scylla-docker-${{ hashFiles('test/docker-compose.yml') }}
+
+      - name: Save Docker image to cache
+        if: steps.docker-cache.outputs.cache-hit != 'true'
+        run: make docker-cache-save
+
+      - name: Cache certificates
+        id: cert-cache
+        uses: actions/cache@v5
+        with:
+          path: .cert-cache
+          key: scylla-certs-${{ hashFiles('Makefile') }}
+
+      - name: Save certificates to cache
+        if: steps.cert-cache.outputs.cache-hit != 'true'
+        run: make cert-cache-save
+
+      - name: Run integration tests
+        run: make test-all
 
       - name: Audit production dependencies
         run: npm audit --omit=dev --audit-level=moderate

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,11 @@ node_modules/
 dist/
 coverage/
 .turbo/
+.docker-cache/
+.cert-cache/
+bin/
+test/scylla/*
+!test/scylla/
+!test/scylla/scylla.yaml
 .DS_Store
 npm-debug.log*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,137 @@
+SHELL := bash
+.ONESHELL:
+.SHELLFLAGS := -eo pipefail -c
+
+MAKEFILE_PATH := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+BIN := $(MAKEFILE_PATH)/bin
+OS := $(shell uname | tr '[:upper:]' '[:lower:]')
+ARCH := $(shell uname -m)
+DOCKER_COMPOSE_VERSION := 2.34.0
+
+ifeq ($(ARCH),aarch64)
+	DOCKER_COMPOSE_DOWNLOAD_URL := "https://github.com/docker/compose/releases/download/v$(DOCKER_COMPOSE_VERSION)/docker-compose-$(OS)-aarch64"
+else ifeq ($(ARCH),x86_64)
+	DOCKER_COMPOSE_DOWNLOAD_URL := "https://github.com/docker/compose/releases/download/v$(DOCKER_COMPOSE_VERSION)/docker-compose-$(OS)-x86_64"
+else
+	$(error Unknown architecture "$(ARCH)")
+endif
+
+COMPOSE = bin/docker-compose -f $(MAKEFILE_PATH)/test/docker-compose.yml
+
+SCYLLA_IMAGE := scylladb/scylla:2025.1
+DOCKER_CACHE_DIR := $(MAKEFILE_PATH)/.docker-cache
+DOCKER_CACHE_FILE := $(DOCKER_CACHE_DIR)/scylla-image.tar
+CERT_CACHE_DIR := $(MAKEFILE_PATH)/.cert-cache
+CERT_DIR := $(MAKEFILE_PATH)/test/scylla
+
+.PHONY: clean verify lint lint-fix test-unit test-integration test-all wait-for-alternator scylla-start scylla-stop scylla-kill scylla-rm docker-pull docker-cache-save docker-cache-load cert-cache-save cert-cache-load
+
+clean:
+	rm -rf dist
+
+verify:
+	npm run verify
+
+lint:
+	npm run lint
+
+lint-fix:
+	npm run lint -- --fix
+
+test-unit:
+	npm test
+
+wait-for-alternator:
+	@echo "Waiting for Alternator to be ready..."
+	@for i in $$(seq 1 60); do \
+		if curl -sf http://172.39.0.2:9998/ >/dev/null 2>&1; then \
+			echo "Alternator is ready (waited $${i}s)"; \
+			break; \
+		fi; \
+		if [ $$i -eq 60 ]; then \
+			echo "Timed out waiting for Alternator"; \
+			$(MAKE) scylla-stop; \
+			exit 1; \
+		fi; \
+		sleep 1; \
+	done
+
+test-integration: scylla-start wait-for-alternator
+	INTEGRATION_TESTS=true \
+	ALTERNATOR_HOST=172.39.0.2 \
+	ALTERNATOR_PORT=9998 \
+	ALTERNATOR_HTTPS_PORT=9999 \
+	ALTERNATOR_CA_CERT_PATH=$$(pwd)/test/scylla/db.crt \
+	npm run test:integration || ($(MAKE) scylla-stop && exit 1)
+	$(MAKE) scylla-stop
+
+test-all: test-integration
+
+.prepare-environment-update-aio-max-nr:
+	@if (( $$(< /proc/sys/fs/aio-max-nr) < 2097152 )); then \
+		echo 2097152 | sudo tee /proc/sys/fs/aio-max-nr >/dev/null; \
+	fi
+
+.prepare-docker-compose: .prepare-bin
+	@if [[ -f "$(BIN)/docker-compose" ]] && "$(BIN)/docker-compose" --version 2>/dev/null | grep "$(DOCKER_COMPOSE_VERSION)" >/dev/null; then \
+		echo "docker-compose $(DOCKER_COMPOSE_VERSION) is already installed"; \
+	else \
+		echo "Downloading $(BIN)/docker-compose"; \
+		curl --progress-bar -L $(DOCKER_COMPOSE_DOWNLOAD_URL) --output "$(BIN)/docker-compose"; \
+		chmod +x "$(BIN)/docker-compose"; \
+	fi
+
+.prepare-bin:
+	@[ -d "$(BIN)" ] || mkdir "$(BIN)"
+
+.prepare-cert:
+	@[ -f "$(CERT_DIR)/db.key" ] || ( \
+		echo "Prepare certificate" && \
+		mkdir -p "$(CERT_DIR)" && \
+		cd "$(CERT_DIR)" && \
+		openssl req -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" -x509 -newkey rsa:4096 -keyout db.key -out db.crt -days 3650 -nodes -addext "subjectAltName=IP:172.39.0.2,IP:172.39.0.3,IP:172.39.0.4" && \
+		chmod 644 db.key \
+	)
+
+scylla-start: cert-cache-load .prepare-docker-compose .prepare-environment-update-aio-max-nr docker-cache-load
+	$(COMPOSE) up -d
+
+scylla-stop: .prepare-docker-compose
+	$(COMPOSE) down
+
+scylla-kill: .prepare-docker-compose
+	$(COMPOSE) kill
+
+scylla-rm: .prepare-docker-compose
+	$(COMPOSE) rm -f
+
+docker-pull:
+	docker pull $(SCYLLA_IMAGE)
+
+docker-cache-save: docker-pull
+	@mkdir -p $(DOCKER_CACHE_DIR)
+	docker save $(SCYLLA_IMAGE) -o $(DOCKER_CACHE_FILE)
+
+docker-cache-load:
+	@if [ -f "$(DOCKER_CACHE_FILE)" ]; then \
+		echo "Loading Docker image from cache..."; \
+		docker load -i "$(DOCKER_CACHE_FILE)"; \
+	else \
+		echo "Cache file not found, pulling image..."; \
+		$(MAKE) docker-pull; \
+	fi
+
+cert-cache-save: .prepare-cert
+	@mkdir -p $(CERT_CACHE_DIR)
+	cp $(CERT_DIR)/db.key $(CERT_DIR)/db.crt $(CERT_CACHE_DIR)/
+
+cert-cache-load:
+	@if [ -f "$(CERT_CACHE_DIR)/db.key" ] && [ -f "$(CERT_CACHE_DIR)/db.crt" ]; then \
+		echo "Loading certificates from cache..."; \
+		mkdir -p "$(CERT_DIR)"; \
+		cp "$(CERT_CACHE_DIR)/db.key" "$(CERT_CACHE_DIR)/db.crt" "$(CERT_DIR)/"; \
+		chmod 644 "$(CERT_DIR)/db.key"; \
+	else \
+		echo "Certificate cache not found, generating..."; \
+		$(MAKE) .prepare-cert; \
+	fi

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ balancing unless the passed client is already an `AlternatorDynamoDBClient`.
 ```ts
 client.getLiveNodes();
 await client.refreshLiveNodes();
-client.nextNode();
 await client.checkRackDatacenterSupport();
 await client.checkIfRackAndDatacenterSetCorrectly();
 await client.validateRackDatacenterConfig();
@@ -225,6 +224,28 @@ plan is exhausted.
 npm run typecheck
 npm run lint
 npm test
+npm run test:integration
 npm run build
 npm run verify
+make test-all
 ```
+
+`npm test` runs the fast unit suite. Integration tests live under
+`test/integration-test` and are skipped unless `INTEGRATION_TESTS` is truthy:
+
+```sh
+INTEGRATION_TESTS=true \
+ALTERNATOR_HOST=172.39.0.2 \
+ALTERNATOR_PORT=9998 \
+ALTERNATOR_HTTPS_PORT=9999 \
+ALTERNATOR_DATACENTER=datacenter1 \
+ALTERNATOR_RACK=rack1 \
+npm run test:integration
+```
+
+For custom CA HTTPS coverage, also set `ALTERNATOR_CA_CERT_PATH` to a PEM CA
+certificate path.
+
+`make test-all` starts the same three-node ScyllaDB Docker cluster shape used by
+the Java client tests, waits for Alternator, runs `npm run test:integration`
+with the required environment variables, and stops the cluster.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "verify": "npm run typecheck && npm run lint && npm run test && npm run build"
   },
   "dependencies": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -72,10 +72,6 @@ export class AlternatorDynamoDBClient extends DynamoDBClient {
     return this.discovery.refreshLiveNodes();
   }
 
-  nextNode(): AlternatorNode {
-    return this.discovery.nextNode();
-  }
-
   checkRackDatacenterSupport(): Promise<boolean> {
     return this.discovery.checkRackDatacenterSupport();
   }

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -12,7 +12,6 @@ interface DiscoveryRequestHandler {
 
 export class AlternatorDiscovery {
   private liveHosts: string[];
-  private cursor = 0;
   private refreshTimer: ReturnType<typeof setInterval> | undefined;
   private lastRefreshAttempt = 0;
   private inFlightRefresh: Promise<AlternatorNode[]> | undefined;
@@ -36,17 +35,6 @@ export class AlternatorDiscovery {
 
   createQueryPlan(preferredNode?: AlternatorNode): AlternatorQueryPlan {
     return new AlternatorQueryPlan(this.getLiveNodes(), [], preferredNode);
-  }
-
-  nextNode(): AlternatorNode {
-    const liveHosts = this.liveHosts.length > 0 ? this.liveHosts : [...this.config.seeds];
-    const index = this.cursor++ % liveHosts.length;
-
-    const host = liveHosts[index];
-    if (!host) {
-      throw new Error("Alternator has no live nodes or seeds configured");
-    }
-    return this.toNode(host);
   }
 
   async refreshLiveNodes(): Promise<AlternatorNode[]> {
@@ -132,7 +120,6 @@ export class AlternatorDiscovery {
           const nodes = await this.fetchLocalNodes(host, query);
           if (nodes.length > 0) {
             this.liveHosts = normalizeDiscoveredHosts(nodes);
-            this.cursor = this.cursor % this.liveHosts.length;
             return this.getLiveNodes();
           }
           this.config.logger.debug?.("alternator discovery: localnodes returned no nodes", { host, query });

--- a/test/COVERAGE_GAPS.md
+++ b/test/COVERAGE_GAPS.md
@@ -1,0 +1,66 @@
+# Java Test Coverage Comparison
+
+Comparison source:
+
+- Java unit tests: `/extra/scylladb/alternator-client-java/src/test/java`
+- Java integration tests: `/extra/scylladb/alternator-client-java/src/integration-test/java`
+- Java integration config: `/extra/scylladb/alternator-client-java/src/test/java/com/scylladb/alternator/IntegrationTestConfig.java`
+
+This list tracks Java-covered behavior that was missing from the JavaScript repo before the
+integration-test suite was added. Java-only features are listed separately and intentionally not
+ported.
+
+## Missing JS Coverage Added
+
+| Java coverage area | Java files | JavaScript coverage |
+| --- | --- | --- |
+| Real-cluster client discovery, live-node access, rack/datacenter routing, wrong-scope fallback, and routing commands through discovered nodes | `AlternatorDynamoDbClientIT`, `AlternatorDynamoDbAsyncClientIT` | `test/integration-test/alternator-client.test.ts` |
+| Real DynamoDB CRUD through the load-balanced client | `DynamoDbOperationsIT`, client CRUD cases in client IT files | `test/integration-test/dynamodb-operations.test.ts` |
+| DynamoDB operations across multiple nodes | `DynamoDbOperationsIT` | `test/integration-test/dynamodb-operations.test.ts` |
+| Document/enhanced-client style access against real tables | `DynamoDbEnhancedClientTest` for Java enhanced client usage | `test/integration-test/dynamodb-operations.test.ts` uses `AlternatorDynamoDBDocumentClient` |
+| Key-route affinity partition-key autodiscovery with `DescribeTable` and post-discovery same-key routing | `KeyRouteAffinityAutodiscoveryIT` | `test/integration-test/key-route-affinity-autodiscovery.test.ts` |
+| Key-route affinity with preconfigured partition key metadata and no extra `DescribeTable` | `KeyRouteAffinityAutodiscoveryIT` | `test/integration-test/key-route-affinity-autodiscovery.test.ts` |
+| Compression behavior against a real endpoint | Compression cases in client IT and HTTP-client implementation IT files | `test/integration-test/alternator-client.test.ts`, `test/integration-test/tls-config.test.ts` |
+| Header optimization behavior against a real endpoint, including disabled defaults and custom allowlists | Header optimization cases in client IT and HTTP-client implementation IT files | `test/integration-test/alternator-client.test.ts`, `test/integration-test/tls-config.test.ts` |
+| Header optimization combined with compression | Client IT and HTTP-client implementation IT files | `test/integration-test/alternator-client.test.ts`, `test/integration-test/tls-config.test.ts` |
+| Java HTTP-client customization/configuration equivalents exposed by JS as `requestHandler` and Node connection options | `HttpClientImplementationSyncIT`, `HttpClientImplementationAsyncIT` | `test/integration-test/http-client-implementation.test.ts`, `test/integration-test/http-connection-reuse.test.ts`, `test/integration-test/internal/connection-pool.test.ts` |
+| Serial, parallel, and idle-period HTTP request reuse | `HttpConnectionReuseIT` | `test/integration-test/http-connection-reuse.test.ts` |
+| Repeated live-node refreshes and SDK operations with pooled connections | `internal/ConnectionPoolIT` | `test/integration-test/internal/connection-pool.test.ts` |
+| HTTPS operation with trust-all behavior, optional custom CA, and custom-CA CRUD | `TlsConfigIT`, HTTPS cases in HTTP-client implementation IT files | `test/integration-test/tls-config.test.ts` |
+| TLS session-cache enabled/disabled behavior with real HTTPS requests | `TlsSessionResumptionIT` | `test/integration-test/tls-session-resumption.test.ts` |
+
+## Existing JS Unit Coverage
+
+These Java unit-test areas already had JavaScript unit coverage and were not duplicated as new
+integration tests:
+
+- Config validation for seeds, scheme, port, runtime, connection options, headers, compression, and TLS.
+- `/localnodes` discovery, rack/datacenter query fallback, request-triggered edge discovery, and live-node access.
+- Alternator middleware request rewriting, retry node selection, no-auth header stripping, SigV4 preservation, header whitelisting, and gzip request compression.
+- Query-plan ordering, seeded random ordering, and retry distribution behavior.
+- Murmur3 and AttributeValue hash vectors shared with the Java tests.
+- Key-route affinity classification for write and read-before-write operations.
+- BatchWriteItem key-affinity voting.
+- Document-client construction, wrapping behavior, and TypeScript public API usage.
+
+## Java-Only Or Absent JS Features Ignored
+
+The following Java test areas are not ported because the JavaScript client does not expose the same
+feature surface:
+
+- Separate synchronous and asynchronous client classes. The AWS SDK v3 JavaScript client is async by
+  design, so the JS integration suite does not duplicate every case as sync and async variants.
+- Apache, Netty, and CRT HTTP client factories, detectors, zero-timeout behavior, and classpath
+  tests. The JS client uses Smithy `NodeHttpHandler` or `FetchHttpHandler`; the JS-equivalent
+  user-provided `requestHandler` path and Node connection options are covered by integration tests.
+- Java wrapper APIs such as `buildWithAlternatorAPI`, `getAlternatorLiveNodes`, Java builder
+  customizer methods, and legacy compatibility methods.
+- Java `DynamoDbEnhancedClient`. The JS equivalent user-facing surface is
+  `AlternatorDynamoDBDocumentClient`, which is covered by integration tests.
+- Java TLS `SSLContext` factory internals, hostname-verifier classes, trust-manager plumbing, and
+  TLS session cache size/timeout settings. The JS client exposes Node TLS agent options and a
+  boolean `sessionCache` toggle.
+- Exact TCP socket-count assertions using `ss` filtered by JVM PID. The JS suite covers the
+  equivalent externally visible behavior: repeated discovery refreshes, serial requests, parallel
+  requests, idle gaps, and bounded socket-pool configuration.
+- Java user-agent wrapper classes. The JS package does not add a separate user-agent HTTP wrapper.

--- a/test/discovery.test.ts
+++ b/test/discovery.test.ts
@@ -31,8 +31,10 @@ describe("Alternator discovery", () => {
         url: "http://node-b.internal:8080",
       },
     ]);
-    expect(client.nextNode().host).toBe("node-a.internal");
-    expect(client.nextNode().host).toBe("node-b.internal");
+    expect(client.getLiveNodes().map((node) => node.host)).toEqual([
+      "node-a.internal",
+      "node-b.internal",
+    ]);
   });
 
   it("tries rack/datacenter routing fallback in order", async () => {

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,89 @@
+networks:
+  public:
+    name: alb-javascript-bridge
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.39.0.0/16
+
+name: alb-javascript
+services:
+  scylla1:
+    image: scylladb/scylla:2025.1
+    networks:
+      public:
+        ipv4_address: 172.39.0.2
+    command: |
+      --rpc-address 172.39.0.2
+      --listen-address 172.39.0.2
+      --seeds 172.39.0.2
+      --skip-wait-for-gossip-to-settle 0
+      --ring-delay-ms 0
+      --smp 2
+      --memory 1G
+    healthcheck:
+      test: [ "CMD", "cqlsh", "scylla1", "-e", "select * from system.local WHERE key='local'" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    ports:
+      - "19042"
+      - "9999"
+      - "9998"
+    volumes:
+      - ./scylla:/etc/scylla
+  scylla2:
+    image: scylladb/scylla:2025.1
+    networks:
+      public:
+        ipv4_address: 172.39.0.3
+    command: |
+      --rpc-address 172.39.0.3
+      --listen-address 172.39.0.3
+      --seeds 172.39.0.2
+      --skip-wait-for-gossip-to-settle 0
+      --ring-delay-ms 0
+      --smp 2
+      --memory 1G
+    healthcheck:
+      test: [ "CMD", "cqlsh", "scylla2", "-e", "select * from system.local WHERE key='local'" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    ports:
+      - "19042"
+      - "9999"
+      - "9998"
+    depends_on:
+      scylla1:
+        condition: service_healthy
+    volumes:
+      - ./scylla:/etc/scylla
+  scylla3:
+    image: scylladb/scylla:2025.1
+    networks:
+      public:
+        ipv4_address: 172.39.0.4
+    command: |
+      --rpc-address 172.39.0.4
+      --listen-address 172.39.0.4
+      --seeds 172.39.0.2,172.39.0.3
+      --skip-wait-for-gossip-to-settle 0
+      --ring-delay-ms 0
+      --smp 2
+      --memory 1G
+    healthcheck:
+      test: [ "CMD", "cqlsh", "scylla3", "-e", "select * from system.local WHERE key='local'" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    ports:
+      - "19042"
+      - "9999"
+      - "9998"
+    depends_on:
+      scylla2:
+        condition: service_healthy
+    volumes:
+      - ./scylla:/etc/scylla

--- a/test/integration-test/alternator-client.test.ts
+++ b/test/integration-test/alternator-client.test.ts
@@ -1,0 +1,290 @@
+import { ListTablesCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { describe, expect, it } from "vitest";
+import { routing } from "../../src/index.js";
+import { describeIntegration, integrationConfig, integrationEndpoints } from "./config.js";
+import {
+  buildClient,
+  captureCommandRequests,
+  commandHeaders,
+  largePayload,
+} from "./helpers.js";
+
+describeIntegration.each(integrationEndpoints())(
+  "AlternatorDynamoDBClient integration ($name)",
+  (endpoint) => {
+    it("discovers nodes for cluster, datacenter, and rack routing scopes", async () => {
+      const cluster = buildClient(endpoint, {
+        routing: routing.cluster(),
+      });
+      const datacenter = buildClient(endpoint, {
+        routing: routing.datacenter(integrationConfig.datacenter, {
+          fallback: routing.cluster(),
+        }),
+      });
+      const rack = buildClient(endpoint, {
+        routing: routing.rack(integrationConfig.datacenter, integrationConfig.rack, {
+          fallback: routing.datacenter(integrationConfig.datacenter, {
+            fallback: routing.cluster(),
+          }),
+        }),
+      });
+
+      try {
+        await expect(cluster.refreshLiveNodes()).resolves.not.toHaveLength(0);
+        await expect(datacenter.refreshLiveNodes()).resolves.not.toHaveLength(0);
+        await expect(rack.refreshLiveNodes()).resolves.not.toHaveLength(0);
+      } finally {
+        cluster.destroy();
+        datacenter.destroy();
+        rack.destroy();
+      }
+    });
+
+    it("falls back from a wrong datacenter or rack to a wider routing scope", async () => {
+      const wrongDatacenter = buildClient(endpoint, {
+        routing: routing.datacenter("__wrong_dc__", {
+          fallback: routing.cluster(),
+        }),
+      });
+      const wrongRack = buildClient(endpoint, {
+        routing: routing.rack(integrationConfig.datacenter, "__wrong_rack__", {
+          fallback: routing.datacenter(integrationConfig.datacenter, {
+            fallback: routing.cluster(),
+          }),
+        }),
+      });
+
+      try {
+        await expect(wrongDatacenter.refreshLiveNodes()).resolves.not.toHaveLength(0);
+        await expect(wrongDatacenter.validateRackDatacenterConfig()).resolves.toBeUndefined();
+
+        await expect(wrongRack.refreshLiveNodes()).resolves.not.toHaveLength(0);
+        await expect(wrongRack.validateRackDatacenterConfig()).resolves.toBeUndefined();
+      } finally {
+        wrongDatacenter.destroy();
+        wrongRack.destroy();
+      }
+    });
+
+    it("checks rack/datacenter query support and exposes live-node APIs", async () => {
+      const client = buildClient(endpoint, {
+        routing: routing.datacenter(integrationConfig.datacenter, {
+          fallback: routing.cluster(),
+        }),
+      });
+
+      try {
+        await expect(client.checkRackDatacenterSupport()).resolves.toBe(true);
+        await expect(client.checkIfRackAndDatacenterSetCorrectly()).resolves.toBeUndefined();
+
+        const nodes = await client.refreshLiveNodes();
+        expect(nodes.length).toBeGreaterThan(0);
+        expect(client.getLiveNodes()).toEqual(nodes);
+      } finally {
+        client.destroy();
+      }
+    });
+
+    it("routes repeated commands through discovered nodes", async () => {
+      const client = buildClient(endpoint, {
+        routing: routing.datacenter(integrationConfig.datacenter, {
+          fallback: routing.cluster(),
+        }),
+      });
+      const captured = captureCommandRequests(client);
+
+      try {
+        const nodes = await client.refreshLiveNodes();
+        expect(nodes.length).toBeGreaterThan(0);
+
+        for (let index = 0; index < nodes.length * 2; index += 1) {
+          await client.send(new ListTablesCommand({ Limit: 1 }));
+        }
+
+        const liveHosts = new Set(nodes.map((node) => node.host));
+        const requestHosts = captured.map((entry) => entry.request.hostname);
+        expect(requestHosts.length).toBe(nodes.length * 2);
+        expect(requestHosts.every((host) => liveHosts.has(host))).toBe(true);
+      } finally {
+        client.destroy();
+      }
+    });
+
+    it("sends commands through discovered nodes", async () => {
+      const client = buildClient(endpoint, {
+        routing: routing.datacenter(integrationConfig.datacenter, {
+          fallback: routing.cluster(),
+        }),
+      });
+      const captured = captureCommandRequests(client);
+
+      try {
+        const nodes = await client.refreshLiveNodes();
+        await client.send(new ListTablesCommand({ Limit: 1 }));
+        await client.send(new ListTablesCommand({ Limit: 1 }));
+
+        const liveHosts = new Set(nodes.map((node) => node.host));
+        const requestHosts = captured.map((entry) => entry.request.hostname);
+        expect(requestHosts.length).toBe(2);
+        expect(requestHosts.every((host) => liveHosts.has(host))).toBe(true);
+      } finally {
+        client.destroy();
+      }
+    });
+
+    it("compresses large requests and leaves small requests uncompressed by threshold", async () => {
+      const client = buildClient(endpoint, {
+        compression: {
+          enabled: true,
+          thresholdBytes: 100,
+        },
+        maxAttempts: 1,
+      });
+      const captured = captureCommandRequests(client);
+
+      try {
+        await expect(
+          client.send(
+            new PutItemCommand({
+              TableName: "nonexistent_table_for_compression_test",
+              Item: {
+                pk: { S: "compression-test" },
+                data: { S: largePayload() },
+              },
+            }),
+          ),
+        ).rejects.toBeDefined();
+
+        await client.send(new ListTablesCommand({ Limit: 1 }));
+
+        expect(commandHeaders(captured, "PutItemCommand")["content-encoding"]).toBe("gzip");
+        expect(commandHeaders(captured, "ListTablesCommand")["content-encoding"]).toBeUndefined();
+      } finally {
+        client.destroy();
+      }
+    });
+
+    it("filters wire headers using the configured whitelist", async () => {
+      const client = buildClient(endpoint, {
+        headerOptimization: {
+          enabled: true,
+          allowedHeaders: ["Host", "X-Amz-Target", "Authorization", "X-Amz-Date"],
+        },
+      });
+      const captured = captureCommandRequests(client);
+
+      try {
+        await client.send(new ListTablesCommand({ Limit: 1 }));
+
+        const headers = commandHeaders(captured, "ListTablesCommand");
+        expect(headers.host).toBeDefined();
+        expect(headers["x-amz-target"]).toBe("DynamoDB_20120810.ListTables");
+        expect(headers.authorization).toContain("AWS4-HMAC-SHA256");
+        expect(headers["x-amz-date"]).toBeDefined();
+        expect(headers["content-type"]).toBeUndefined();
+        expect(headers["x-amz-content-sha256"]).toBeUndefined();
+      } finally {
+        client.destroy();
+      }
+    });
+
+    it("preserves normal SDK wire headers when header optimization is disabled", async () => {
+      const client = buildClient(endpoint);
+      const captured = captureCommandRequests(client);
+
+      try {
+        await client.send(new ListTablesCommand({ Limit: 1 }));
+
+        const headers = commandHeaders(captured, "ListTablesCommand");
+        expect(headers.host).toBeDefined();
+        expect(headers["x-amz-target"]).toBe("DynamoDB_20120810.ListTables");
+        expect(headers.authorization).toContain("AWS4-HMAC-SHA256");
+        expect(headers["x-amz-date"]).toBeDefined();
+        expect(headers["content-type"]).toBe("application/x-amz-json-1.0");
+        expect(headers["x-amz-content-sha256"]).toBeDefined();
+      } finally {
+        client.destroy();
+      }
+    });
+
+    it("keeps custom-whitelisted headers when header optimization is enabled", async () => {
+      const client = buildClient(endpoint, {
+        headerOptimization: {
+          enabled: true,
+          allowedHeaders: [
+            "Host",
+            "X-Amz-Target",
+            "Authorization",
+            "X-Amz-Date",
+            "Content-Type",
+            "Content-Length",
+          ],
+        },
+      });
+      const captured = captureCommandRequests(client);
+
+      try {
+        await client.send(new ListTablesCommand({ Limit: 1 }));
+
+        const headers = commandHeaders(captured, "ListTablesCommand");
+        expect(headers.host).toBeDefined();
+        expect(headers["x-amz-target"]).toBe("DynamoDB_20120810.ListTables");
+        expect(headers.authorization).toContain("AWS4-HMAC-SHA256");
+        expect(headers["x-amz-date"]).toBeDefined();
+        expect(headers["content-type"]).toBe("application/x-amz-json-1.0");
+        expect(headers["x-amz-content-sha256"]).toBeUndefined();
+      } finally {
+        client.destroy();
+      }
+    });
+
+    it("keeps compression headers when header optimization and compression are combined", async () => {
+      const client = buildClient(endpoint, {
+        compression: {
+          enabled: true,
+          thresholdBytes: 100,
+        },
+        headerOptimization: {
+          enabled: true,
+          allowedHeaders: [
+            "Host",
+            "X-Amz-Target",
+            "Authorization",
+            "X-Amz-Date",
+            "Content-Length",
+            "Content-Encoding",
+          ],
+        },
+        maxAttempts: 1,
+      });
+      const captured = captureCommandRequests(client);
+
+      try {
+        await expect(
+          client.send(
+            new PutItemCommand({
+              TableName: "nonexistent_table_for_headers_compression_test",
+              Item: {
+                pk: { S: "combined-test" },
+                data: { S: largePayload() },
+              },
+            }),
+          ),
+        ).rejects.toBeDefined();
+
+        const headers = commandHeaders(captured, "PutItemCommand");
+        expect(headers["content-encoding"]).toBe("gzip");
+        expect(headers["content-length"]).toBeDefined();
+        expect(headers["content-type"]).toBeUndefined();
+      } finally {
+        client.destroy();
+      }
+    });
+  },
+);
+
+describe("integration test opt-in", () => {
+  it("is disabled unless INTEGRATION_TESTS is truthy", () => {
+    expect(typeof integrationConfig.enabled).toBe("boolean");
+  });
+});

--- a/test/integration-test/config.ts
+++ b/test/integration-test/config.ts
@@ -1,0 +1,65 @@
+import { describe } from "vitest";
+import type { AlternatorScheme } from "../../src/index.js";
+
+export interface IntegrationEndpoint {
+  readonly name: string;
+  readonly host: string;
+  readonly scheme: AlternatorScheme;
+  readonly port: number;
+}
+
+export const integrationConfig = {
+  enabled: truthy(process.env.INTEGRATION_TESTS),
+  host: process.env.ALTERNATOR_HOST ?? "172.39.0.2",
+  httpPort: intEnv("ALTERNATOR_PORT", 9998),
+  httpsPort: intEnv("ALTERNATOR_HTTPS_PORT", 9999),
+  datacenter: process.env.ALTERNATOR_DATACENTER ?? "datacenter1",
+  rack: process.env.ALTERNATOR_RACK ?? "rack1",
+  caCertPath: process.env.ALTERNATOR_CA_CERT_PATH,
+  credentials: {
+    accessKeyId: process.env.ALTERNATOR_ACCESS_KEY_ID ?? "test",
+    secretAccessKey: process.env.ALTERNATOR_SECRET_ACCESS_KEY ?? "test",
+  },
+} as const;
+
+export const describeIntegration = (
+  integrationConfig.enabled ? describe : describe.skip
+) as unknown as typeof describe;
+
+export function integrationEndpoints(): IntegrationEndpoint[] {
+  return [
+    {
+      name: "http",
+      host: integrationConfig.host,
+      scheme: "http",
+      port: integrationConfig.httpPort,
+    },
+    {
+      name: "https",
+      host: integrationConfig.host,
+      scheme: "https",
+      port: integrationConfig.httpsPort,
+    },
+  ];
+}
+
+export function httpsIntegrationEndpoints(): IntegrationEndpoint[] {
+  return integrationEndpoints().filter((endpoint) => endpoint.scheme === "https");
+}
+
+function truthy(value: string | undefined): boolean {
+  return value === "true" || value === "1" || value === "yes";
+}
+
+function intEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isInteger(value) || value < 1 || value > 65535) {
+    throw new Error(`${name} must be an integer port between 1 and 65535`);
+  }
+  return value;
+}

--- a/test/integration-test/dynamodb-operations.test.ts
+++ b/test/integration-test/dynamodb-operations.test.ts
@@ -1,0 +1,142 @@
+import { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { DeleteItemCommand, GetItemCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { expect, it } from "vitest";
+import { describeIntegration, integrationEndpoints } from "./config.js";
+import {
+  buildClient,
+  buildDocumentClient,
+  createStringHashTable,
+  getStringItem,
+  putStringItem,
+  safeDeleteTable,
+  uniqueTableName,
+} from "./helpers.js";
+
+describeIntegration.each(integrationEndpoints())(
+  "DynamoDB operations integration ($name)",
+  (endpoint) => {
+    it("performs low-level CRUD operations through the load-balanced client", async () => {
+      const tableName = uniqueTableName("js_crud_it");
+      const client = buildClient(endpoint);
+
+      try {
+        await safeDeleteTable(client, tableName);
+        await createStringHashTable(client, tableName);
+
+        await putStringItem(client, tableName, "item-1", {
+          data: { S: "hello-world" },
+          count: { N: "42" },
+        });
+
+        const item = await getStringItem(client, tableName, "item-1");
+        expect(item?.pk?.S).toBe("item-1");
+        expect(item?.data?.S).toBe("hello-world");
+        expect(item?.count?.N).toBe("42");
+
+        await client.send(
+          new DeleteItemCommand({
+            TableName: tableName,
+            Key: { pk: { S: "item-1" } },
+          }),
+        );
+
+        const deleted = await getStringItem(client, tableName, "item-1");
+        expect(deleted).toBeUndefined();
+      } finally {
+        await safeDeleteTable(client, tableName);
+        client.destroy();
+      }
+    });
+
+    it("performs document-client CRUD operations through the Alternator client", async () => {
+      const tableName = uniqueTableName("js_doc_crud_it");
+      const setupClient = buildClient(endpoint);
+      const documentClient = buildDocumentClient(endpoint, {}, {
+        marshallOptions: {
+          removeUndefinedValues: true,
+        },
+      });
+
+      try {
+        await safeDeleteTable(setupClient, tableName);
+        await createStringHashTable(setupClient, tableName);
+
+        await documentClient.send(
+          new PutCommand({
+            TableName: tableName,
+            Item: {
+              pk: "doc-1",
+              data: "document-value",
+              skipped: undefined,
+            },
+          }),
+        );
+
+        const response = await documentClient.send(
+          new GetCommand({
+            TableName: tableName,
+            Key: { pk: "doc-1" },
+            ConsistentRead: true,
+          }),
+        );
+        expect(response.Item).toEqual({
+          pk: "doc-1",
+          data: "document-value",
+        });
+
+        await documentClient.send(
+          new DeleteCommand({
+            TableName: tableName,
+            Key: { pk: "doc-1" },
+          }),
+        );
+      } finally {
+        documentClient.destroy();
+        await safeDeleteTable(setupClient, tableName);
+        setupClient.destroy();
+      }
+    });
+
+    it("keeps data readable when writes and reads are spread across nodes", async () => {
+      const tableName = uniqueTableName("js_multinode_it");
+      const client = buildClient(endpoint);
+      const itemCount = 30;
+
+      try {
+        await safeDeleteTable(client, tableName);
+        await createStringHashTable(client, tableName);
+        await client.refreshLiveNodes();
+
+        for (let index = 0; index < itemCount; index += 1) {
+          await client.send(
+            new PutItemCommand({
+              TableName: tableName,
+              Item: {
+                pk: { S: `key-${index}` },
+                value: { S: `value-${index}` },
+                itemIndex: { N: String(index) },
+              },
+            }),
+          );
+        }
+
+        for (let index = 0; index < itemCount; index += 1) {
+          const response = await client.send(
+            new GetItemCommand({
+              TableName: tableName,
+              Key: { pk: { S: `key-${index}` } },
+              ConsistentRead: true,
+            }),
+          );
+
+          expect(response.Item?.pk?.S).toBe(`key-${index}`);
+          expect(response.Item?.value?.S).toBe(`value-${index}`);
+          expect(response.Item?.itemIndex?.N).toBe(String(index));
+        }
+      } finally {
+        await safeDeleteTable(client, tableName);
+        client.destroy();
+      }
+    });
+  },
+);

--- a/test/integration-test/helpers.ts
+++ b/test/integration-test/helpers.ts
@@ -1,0 +1,251 @@
+import {
+  CreateTableCommand,
+  DeleteItemCommand,
+  DeleteTableCommand,
+  DescribeTableCommand,
+  GetItemCommand,
+  ListTablesCommand,
+  PutItemCommand,
+  type AttributeValue,
+  type DynamoDBClient,
+  type ServiceInputTypes,
+  type ServiceOutputTypes,
+} from "@aws-sdk/client-dynamodb";
+import { HttpRequest } from "@smithy/protocol-http";
+import type { FinalizeRequestMiddleware } from "@smithy/types";
+import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
+import type { AlternatorDynamoDBClientConfig } from "../../src/index.js";
+import { AlternatorDynamoDBClient } from "../../src/index.js";
+import { AlternatorDynamoDBDocumentClient, type TranslateConfig } from "../../src/document.js";
+import { integrationConfig, type IntegrationEndpoint } from "./config.js";
+
+type ClientOverrides = Omit<Partial<AlternatorDynamoDBClientConfig>, "seeds" | "scheme" | "port">;
+
+export interface CapturedCommandRequest {
+  readonly commandName: string | undefined;
+  readonly request: HttpRequest;
+}
+
+let captureMiddlewareId = 0;
+
+export function buildClient(
+  endpoint: IntegrationEndpoint,
+  overrides: ClientOverrides = {},
+): AlternatorDynamoDBClient {
+  const tls = endpoint.scheme === "https"
+    ? {
+        rejectUnauthorized: false,
+        ...overrides.tls,
+      }
+    : overrides.tls;
+
+  return new AlternatorDynamoDBClient({
+    ...overrides,
+    seeds: [endpoint.host],
+    scheme: endpoint.scheme,
+    port: endpoint.port,
+    credentials: overrides.credentials ?? integrationConfig.credentials,
+    discovery: {
+      background: false,
+      ...overrides.discovery,
+    },
+    ...(tls ? { tls } : {}),
+  });
+}
+
+export function buildDocumentClient(
+  endpoint: IntegrationEndpoint,
+  overrides: ClientOverrides = {},
+  translateConfig?: TranslateConfig,
+): AlternatorDynamoDBDocumentClient {
+  return new AlternatorDynamoDBDocumentClient(
+    {
+      ...overrides,
+      seeds: [endpoint.host],
+      scheme: endpoint.scheme,
+      port: endpoint.port,
+      credentials: overrides.credentials ?? integrationConfig.credentials,
+      discovery: {
+        background: false,
+        ...overrides.discovery,
+      },
+      ...(endpoint.scheme === "https"
+        ? {
+            tls: {
+              rejectUnauthorized: false,
+              ...overrides.tls,
+            },
+          }
+        : overrides.tls
+          ? { tls: overrides.tls }
+          : {}),
+    },
+    translateConfig,
+  );
+}
+
+export function captureCommandRequests(client: AlternatorDynamoDBClient): CapturedCommandRequest[] {
+  const captured: CapturedCommandRequest[] = [];
+  const name = `integrationCaptureCommandRequests${captureMiddlewareId++}`;
+  const captureMiddleware: FinalizeRequestMiddleware<ServiceInputTypes, ServiceOutputTypes> = (next, context) => (args) => {
+    if (HttpRequest.isInstance(args.request)) {
+      captured.push({
+        commandName: context.commandName,
+        request: HttpRequest.clone(args.request),
+      });
+    }
+    return next(args);
+  };
+
+  client.middlewareStack.addRelativeTo(
+    captureMiddleware,
+    {
+      relation: "after",
+      toMiddleware: "alternatorPostSigningMiddleware",
+      name,
+      override: true,
+    },
+  );
+
+  return captured;
+}
+
+export function commandHeaders(
+  captured: readonly CapturedCommandRequest[],
+  commandName: string,
+): Record<string, string | undefined> {
+  return captured.find((entry) => entry.commandName === commandName)?.request.headers ?? {};
+}
+
+export async function createStringHashTable(
+  client: DynamoDBClient,
+  tableName: string,
+  partitionKey = "pk",
+): Promise<void> {
+  await client.send(
+    new CreateTableCommand({
+      TableName: tableName,
+      KeySchema: [{ AttributeName: partitionKey, KeyType: "HASH" }],
+      AttributeDefinitions: [{ AttributeName: partitionKey, AttributeType: "S" }],
+      ProvisionedThroughput: {
+        ReadCapacityUnits: 1,
+        WriteCapacityUnits: 1,
+      },
+    }),
+  );
+}
+
+export async function safeDeleteTable(client: DynamoDBClient, tableName: string): Promise<void> {
+  try {
+    await client.send(new DeleteTableCommand({ TableName: tableName }));
+  } catch (error) {
+    if (!isResourceNotFound(error)) {
+      throw error;
+    }
+  }
+}
+
+export async function safeDeleteItem(
+  client: DynamoDBClient,
+  tableName: string,
+  key: Record<string, AttributeValue>,
+): Promise<void> {
+  try {
+    await client.send(new DeleteItemCommand({ TableName: tableName, Key: key }));
+  } catch (error) {
+    if (!isResourceNotFound(error)) {
+      throw error;
+    }
+  }
+}
+
+export async function putStringItem(
+  client: DynamoDBClient,
+  tableName: string,
+  pk: string,
+  attributes: Record<string, AttributeValue> = {},
+): Promise<void> {
+  await client.send(
+    new PutItemCommand({
+      TableName: tableName,
+      Item: {
+        pk: { S: pk },
+        ...attributes,
+      },
+    }),
+  );
+}
+
+export async function getStringItem(
+  client: DynamoDBClient,
+  tableName: string,
+  pk: string,
+): Promise<Record<string, AttributeValue> | undefined> {
+  const response = await client.send(
+    new GetItemCommand({
+      TableName: tableName,
+      Key: { pk: { S: pk } },
+      ConsistentRead: true,
+    }),
+  );
+  return response.Item;
+}
+
+export async function assertTableIsUsable(client: DynamoDBClient, tableName: string): Promise<void> {
+  await client.send(new DescribeTableCommand({ TableName: tableName }));
+}
+
+export async function assertListTablesSucceeds(client: DynamoDBClient): Promise<void> {
+  await client.send(new ListTablesCommand({ Limit: 1 }));
+}
+
+export function uniqueTableName(prefix: string): string {
+  return `${prefix}_${randomUUID().replaceAll("-", "").slice(0, 12)}`;
+}
+
+export function largePayload(): string {
+  return "This is a test value that should be compressed. ".repeat(100);
+}
+
+export function customCaAvailable(): boolean {
+  return integrationConfig.caCertPath !== undefined && existsSync(integrationConfig.caCertPath);
+}
+
+export async function waitFor<T>(
+  probe: () => T | undefined | false | Promise<T | undefined | false>,
+  description: string,
+  timeoutMs = 10_000,
+  intervalMs = 100,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let lastValue: T | undefined | false;
+
+  while (Date.now() <= deadline) {
+    lastValue = await probe();
+    if (lastValue) {
+      return lastValue;
+    }
+    await sleep(intervalMs);
+  }
+
+  throw new Error(`Timed out waiting for ${description}; last value: ${String(lastValue)}`);
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export function isResourceNotFound(error: unknown): boolean {
+  return isRecord(error) && (
+    error.name === "ResourceNotFoundException" ||
+    error.__type === "com.amazonaws.dynamodb.v20120810#ResourceNotFoundException" ||
+    error.__type === "ResourceNotFoundException"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/test/integration-test/http-client-implementation.test.ts
+++ b/test/integration-test/http-client-implementation.test.ts
@@ -1,0 +1,44 @@
+import { ListTablesCommand } from "@aws-sdk/client-dynamodb";
+import { NodeHttpHandler } from "@smithy/node-http-handler";
+import { Agent as HttpAgent } from "node:http";
+import { Agent as HttpsAgent } from "node:https";
+import { expect, it } from "vitest";
+import { describeIntegration, integrationEndpoints } from "./config.js";
+import { buildClient } from "./helpers.js";
+
+describeIntegration.each(integrationEndpoints())(
+  "HTTP request handler integration ($name)",
+  (endpoint) => {
+    it("uses a delegated custom request handler for discovery and SDK commands", async () => {
+      const delegate = new NodeHttpHandler({
+        httpAgent: new HttpAgent({
+          keepAlive: true,
+          maxSockets: 4,
+        }),
+        httpsAgent: new HttpsAgent({
+          keepAlive: true,
+          maxSockets: 4,
+          rejectUnauthorized: false,
+        }),
+      });
+      const handledPaths: string[] = [];
+      const delegateHandle = delegate.handle.bind(delegate);
+      delegate.handle = (request, options) => {
+        handledPaths.push(request.path);
+        return delegateHandle(request, options);
+      };
+
+      const client = buildClient(endpoint, { requestHandler: delegate });
+
+      try {
+        await expect(client.refreshLiveNodes()).resolves.not.toHaveLength(0);
+        await expect(client.send(new ListTablesCommand({ Limit: 1 }))).resolves.toBeDefined();
+
+        expect(handledPaths).toContain("/localnodes");
+        expect(handledPaths).toContain("/");
+      } finally {
+        client.destroy();
+      }
+    });
+  },
+);

--- a/test/integration-test/http-connection-reuse.test.ts
+++ b/test/integration-test/http-connection-reuse.test.ts
@@ -1,0 +1,74 @@
+import { ListTablesCommand } from "@aws-sdk/client-dynamodb";
+import { expect, it } from "vitest";
+import { describeIntegration, integrationEndpoints } from "./config.js";
+import { buildClient } from "./helpers.js";
+
+describeIntegration.each(integrationEndpoints())(
+  "HTTP connection reuse integration ($name)",
+  (endpoint) => {
+    it("handles rapid serial requests through the default Node HTTP handler", async () => {
+      const client = buildClient(endpoint, {
+        connection: {
+          keepAlive: true,
+          maxSockets: 16,
+        },
+      });
+
+      try {
+        let successes = 0;
+        for (let index = 0; index < 20; index += 1) {
+          await client.send(new ListTablesCommand({ Limit: 1 }));
+          successes += 1;
+        }
+
+        expect(successes).toBe(20);
+      } finally {
+        client.destroy();
+      }
+    });
+
+    it("handles parallel requests with a bounded socket pool", async () => {
+      const client = buildClient(endpoint, {
+        connection: {
+          keepAlive: true,
+          maxSockets: 4,
+        },
+      });
+
+      try {
+        const responses = await Promise.all(
+          Array.from({ length: 50 }, () => client.send(new ListTablesCommand({ Limit: 1 }))),
+        );
+
+        expect(responses).toHaveLength(50);
+      } finally {
+        client.destroy();
+      }
+    });
+
+    it("continues to use the client successfully after a short idle period", async () => {
+      const client = buildClient(endpoint, {
+        connection: {
+          keepAlive: true,
+          maxSockets: 8,
+        },
+      });
+
+      try {
+        for (let index = 0; index < 10; index += 1) {
+          await client.send(new ListTablesCommand({ Limit: 1 }));
+        }
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 2_000);
+        });
+
+        for (let index = 0; index < 10; index += 1) {
+          await client.send(new ListTablesCommand({ Limit: 1 }));
+        }
+      } finally {
+        client.destroy();
+      }
+    });
+  },
+);

--- a/test/integration-test/internal/connection-pool.test.ts
+++ b/test/integration-test/internal/connection-pool.test.ts
@@ -1,0 +1,55 @@
+import { ListTablesCommand } from "@aws-sdk/client-dynamodb";
+import { expect, it } from "vitest";
+import { describeIntegration, integrationEndpoints } from "../config.js";
+import { buildClient, sleep } from "../helpers.js";
+
+describeIntegration.each(integrationEndpoints())(
+  "internal connection pool integration ($name)",
+  (endpoint) => {
+    it("can refresh live nodes repeatedly without exhausting the request handler", async () => {
+      const client = buildClient(endpoint, {
+        connection: {
+          keepAlive: true,
+          maxSockets: 4,
+        },
+      });
+
+      try {
+        for (let index = 0; index < 30; index += 1) {
+          await client.refreshLiveNodes();
+        }
+
+        expect(client.getLiveNodes().length).toBeGreaterThan(0);
+      } finally {
+        client.destroy();
+      }
+    });
+
+    it("continues to serve SDK operations after idle gaps with header optimization enabled", async () => {
+      const client = buildClient(endpoint, {
+        headerOptimization: true,
+        connection: {
+          keepAlive: true,
+          maxSockets: 8,
+        },
+      });
+
+      try {
+        await client.refreshLiveNodes();
+        for (let index = 0; index < 10; index += 1) {
+          await client.send(new ListTablesCommand({ Limit: 1 }));
+          await sleep(250);
+        }
+
+        await sleep(2_000);
+
+        const responses = await Promise.all(
+          Array.from({ length: 10 }, () => client.send(new ListTablesCommand({ Limit: 1 }))),
+        );
+        expect(responses).toHaveLength(10);
+      } finally {
+        client.destroy();
+      }
+    });
+  },
+);

--- a/test/integration-test/key-route-affinity-autodiscovery.test.ts
+++ b/test/integration-test/key-route-affinity-autodiscovery.test.ts
@@ -1,0 +1,180 @@
+import { GetItemCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { expect, it } from "vitest";
+import { describeIntegration, integrationEndpoints } from "./config.js";
+import {
+  buildClient,
+  captureCommandRequests,
+  createStringHashTable,
+  safeDeleteTable,
+  uniqueTableName,
+  waitFor,
+} from "./helpers.js";
+
+describeIntegration.each(integrationEndpoints())(
+  "key route affinity autodiscovery integration ($name)",
+  (endpoint) => {
+    it("discovers the table partition key with DescribeTable", async () => {
+      const tableName = uniqueTableName("js_affinity_discover_it");
+      const client = buildClient(endpoint, {
+        keyRouteAffinity: {
+          type: "any-write",
+        },
+      });
+      const captured = captureCommandRequests(client);
+
+      try {
+        await safeDeleteTable(client, tableName);
+        await createStringHashTable(client, tableName, "user_id");
+        const nodes = await client.refreshLiveNodes();
+
+        await client.send(
+          new PutItemCommand({
+            TableName: tableName,
+            Item: {
+              user_id: { S: "user-001" },
+              name: { S: "Alice" },
+            },
+          }),
+        );
+
+        await waitFor(
+          () => client.getPartitionKeyName(tableName) === "user_id" ? "user_id" : undefined,
+          "partition-key autodiscovery",
+        );
+
+        expect(captured.some((entry) => entry.commandName === "DescribeTableCommand")).toBe(true);
+        expect(client.getPartitionKeyName(tableName)).toBe("user_id");
+
+        captured.length = 0;
+        for (let index = 0; index < 10; index += 1) {
+          await client.send(
+            new PutItemCommand({
+              TableName: tableName,
+              Item: {
+                user_id: { S: "user-002" },
+                name: { S: `Bob-${index}` },
+              },
+            }),
+          );
+        }
+
+        const repeatedPutHosts = captured
+          .filter((entry) => entry.commandName === "PutItemCommand")
+          .map((entry) => entry.request.hostname);
+        expect(repeatedPutHosts).toHaveLength(10);
+        if (nodes.length > 1) {
+          expect(new Set(repeatedPutHosts).size).toBe(1);
+        }
+
+        await client.send(
+          new PutItemCommand({
+            TableName: tableName,
+            Item: {
+              user_id: { S: "user-003" },
+              name: { S: "Carol" },
+            },
+          }),
+        );
+
+        const response = await client.send(
+          new GetItemCommand({
+            TableName: tableName,
+            Key: { user_id: { S: "user-003" } },
+            ConsistentRead: true,
+          }),
+        );
+        expect(response.Item?.name?.S).toBe("Carol");
+      } finally {
+        await safeDeleteTable(client, tableName);
+        client.destroy();
+      }
+    });
+
+    it("routes repeated writes for the same preconfigured key to the same first node", async () => {
+      const tableName = uniqueTableName("js_affinity_preconf_it");
+      const client = buildClient(endpoint, {
+        keyRouteAffinity: {
+          type: "any-write",
+          partitionKeys: {
+            [tableName]: "user_id",
+          },
+        },
+        maxAttempts: 1,
+      });
+      const captured = captureCommandRequests(client);
+
+      try {
+        await safeDeleteTable(client, tableName);
+        await createStringHashTable(client, tableName, "user_id");
+        const nodes = await client.refreshLiveNodes();
+
+        for (let index = 0; index < 10; index += 1) {
+          await client.send(
+            new PutItemCommand({
+              TableName: tableName,
+              Item: {
+                user_id: { S: "preconf-user" },
+                seq: { N: String(index) },
+              },
+            }),
+          );
+        }
+
+        const putHosts = captured
+          .filter((entry) => entry.commandName === "PutItemCommand")
+          .map((entry) => entry.request.hostname);
+
+        expect(putHosts).toHaveLength(10);
+        if (nodes.length > 1) {
+          expect(new Set(putHosts).size).toBe(1);
+        }
+
+        const response = await client.send(
+          new GetItemCommand({
+            TableName: tableName,
+            Key: { user_id: { S: "preconf-user" } },
+            ConsistentRead: true,
+          }),
+        );
+        expect(response.Item?.seq?.N).toBe("9");
+      } finally {
+        await safeDeleteTable(client, tableName);
+        client.destroy();
+      }
+    });
+
+    it("does not issue DescribeTable when partition-key metadata is preconfigured", async () => {
+      const tableName = uniqueTableName("js_affinity_no_describe_it");
+      const client = buildClient(endpoint, {
+        keyRouteAffinity: {
+          type: "any-write",
+          partitionKeys: {
+            [tableName]: "user_id",
+          },
+        },
+      });
+      const captured = captureCommandRequests(client);
+
+      try {
+        await safeDeleteTable(client, tableName);
+        await createStringHashTable(client, tableName, "user_id");
+        await client.refreshLiveNodes();
+
+        await client.send(
+          new PutItemCommand({
+            TableName: tableName,
+            Item: {
+              user_id: { S: "user-001" },
+              name: { S: "Alice" },
+            },
+          }),
+        );
+
+        expect(captured.some((entry) => entry.commandName === "DescribeTableCommand")).toBe(false);
+      } finally {
+        await safeDeleteTable(client, tableName);
+        client.destroy();
+      }
+    });
+  },
+);

--- a/test/integration-test/tls-config.test.ts
+++ b/test/integration-test/tls-config.test.ts
@@ -1,0 +1,136 @@
+import { ListTablesCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { expect, it } from "vitest";
+import { routing } from "../../src/index.js";
+import { describeIntegration, integrationConfig, httpsIntegrationEndpoints } from "./config.js";
+import {
+  buildClient,
+  captureCommandRequests,
+  commandHeaders,
+  createStringHashTable,
+  customCaAvailable,
+  getStringItem,
+  largePayload,
+  putStringItem,
+  safeDeleteTable,
+  uniqueTableName,
+} from "./helpers.js";
+
+const itWithCustomCa = customCaAvailable() ? it : it.skip;
+
+describeIntegration.each(httpsIntegrationEndpoints())(
+  "TLS config integration ($name)",
+  (endpoint) => {
+    it("connects over HTTPS with certificate validation disabled", async () => {
+      const client = buildClient(endpoint, {
+        tls: {
+          rejectUnauthorized: false,
+        },
+      });
+
+      try {
+        await expect(client.refreshLiveNodes()).resolves.not.toHaveLength(0);
+        await expect(client.send(new ListTablesCommand({ Limit: 1 }))).resolves.toBeDefined();
+      } finally {
+        client.destroy();
+      }
+    });
+
+    itWithCustomCa("connects over HTTPS with a custom CA certificate when configured", async () => {
+      const caCertPath = integrationConfig.caCertPath;
+      if (!caCertPath) {
+        throw new Error("ALTERNATOR_CA_CERT_PATH is required for the custom CA test");
+      }
+
+      const client = buildClient(endpoint, {
+        tls: {
+          caFile: caCertPath,
+          rejectUnauthorized: true,
+        },
+      });
+
+      try {
+        await expect(client.refreshLiveNodes()).resolves.not.toHaveLength(0);
+        await expect(client.send(new ListTablesCommand({ Limit: 1 }))).resolves.toBeDefined();
+      } finally {
+        client.destroy();
+      }
+    });
+
+    itWithCustomCa("performs CRUD over HTTPS with a custom CA certificate", async () => {
+      const caCertPath = integrationConfig.caCertPath;
+      if (!caCertPath) {
+        throw new Error("ALTERNATOR_CA_CERT_PATH is required for the custom CA CRUD test");
+      }
+
+      const tableName = uniqueTableName("js_tls_ca_crud_it");
+      const client = buildClient(endpoint, {
+        tls: {
+          caFile: caCertPath,
+          rejectUnauthorized: true,
+        },
+      });
+
+      try {
+        await safeDeleteTable(client, tableName);
+        await createStringHashTable(client, tableName);
+        await putStringItem(client, tableName, "ca-item-1", {
+          data: { S: "custom-ca-crud" },
+        });
+
+        const item = await getStringItem(client, tableName, "ca-item-1");
+        expect(item?.pk?.S).toBe("ca-item-1");
+        expect(item?.data?.S).toBe("custom-ca-crud");
+      } finally {
+        await safeDeleteTable(client, tableName);
+        client.destroy();
+      }
+    });
+
+    it("combines HTTPS, routing scope, compression, and header optimization", async () => {
+      const client = buildClient(endpoint, {
+        routing: routing.cluster(),
+        tls: {
+          rejectUnauthorized: false,
+        },
+        compression: {
+          enabled: true,
+          thresholdBytes: 100,
+        },
+        headerOptimization: {
+          enabled: true,
+          allowedHeaders: [
+            "Host",
+            "X-Amz-Target",
+            "Authorization",
+            "X-Amz-Date",
+            "Content-Length",
+            "Content-Encoding",
+          ],
+        },
+        maxAttempts: 1,
+      });
+      const captured = captureCommandRequests(client);
+
+      try {
+        await client.refreshLiveNodes();
+        await expect(
+          client.send(
+            new PutItemCommand({
+              TableName: "nonexistent_tls_combined_test",
+              Item: {
+                pk: { S: "tls-combined" },
+                data: { S: largePayload() },
+              },
+            }),
+          ),
+        ).rejects.toBeDefined();
+
+        const headers = commandHeaders(captured, "PutItemCommand");
+        expect(headers["content-encoding"]).toBe("gzip");
+        expect(headers.authorization).toContain("AWS4-HMAC-SHA256");
+      } finally {
+        client.destroy();
+      }
+    });
+  },
+);

--- a/test/integration-test/tls-session-resumption.test.ts
+++ b/test/integration-test/tls-session-resumption.test.ts
@@ -1,0 +1,64 @@
+import { ListTablesCommand } from "@aws-sdk/client-dynamodb";
+import { expect, it } from "vitest";
+import { routing } from "../../src/index.js";
+import { describeIntegration, httpsIntegrationEndpoints } from "./config.js";
+import { buildClient } from "./helpers.js";
+
+describeIntegration.each(httpsIntegrationEndpoints())(
+  "TLS session cache integration ($name)",
+  (endpoint) => {
+    it("keeps HTTPS requests working with the default Node TLS session cache", async () => {
+      const client = buildClient(endpoint, {
+        tls: {
+          rejectUnauthorized: false,
+        },
+      });
+
+      try {
+        for (let index = 0; index < 10; index += 1) {
+          await client.send(new ListTablesCommand({ Limit: 1 }));
+        }
+        expect(client.alternatorConfig.tls?.sessionCache).toBeUndefined();
+      } finally {
+        client.destroy();
+      }
+    });
+
+    it("keeps HTTPS requests working when TLS session caching is disabled", async () => {
+      const client = buildClient(endpoint, {
+        tls: {
+          rejectUnauthorized: false,
+          sessionCache: false,
+        },
+      });
+
+      try {
+        for (let index = 0; index < 5; index += 1) {
+          await client.send(new ListTablesCommand({ Limit: 1 }));
+        }
+        expect(client.alternatorConfig.tls?.sessionCache).toBe(false);
+      } finally {
+        client.destroy();
+      }
+    });
+
+    it("combines TLS session cache settings with routing and header optimization", async () => {
+      const client = buildClient(endpoint, {
+        routing: routing.cluster(),
+        tls: {
+          rejectUnauthorized: false,
+          sessionCache: true,
+        },
+        headerOptimization: true,
+      });
+
+      try {
+        await expect(client.refreshLiveNodes()).resolves.not.toHaveLength(0);
+        await expect(client.send(new ListTablesCommand({ Limit: 1 }))).resolves.toBeDefined();
+        expect(client.alternatorConfig.tls?.sessionCache).toBe(true);
+      } finally {
+        client.destroy();
+      }
+    });
+  },
+);

--- a/test/scylla/scylla.yaml
+++ b/test/scylla/scylla.yaml
@@ -1,0 +1,32 @@
+num_tokens: 256
+
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+commitlog_segment_size_in_mb: 32
+schema_commitlog_segment_size_in_mb: 128
+
+seed_provider:
+  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    parameters:
+      - seeds: "127.0.0.1"
+
+listen_address: localhost
+rpc_address: localhost
+endpoint_snitch: SimpleSnitch
+
+native_transport_port: 9042
+native_shard_aware_transport_port: 19042
+native_transport_port_ssl: 9142
+native_shard_aware_transport_port_ssl: 19142
+
+api_port: 10000
+api_address: 127.0.0.1
+
+alternator_encryption_options:
+  enable_session_tickets: true
+  certificate: /etc/scylla/db.crt
+  keyfile: /etc/scylla/db.key
+
+alternator_https_port: 9999
+alternator_port: 9998
+alternator_write_isolation: only_rmw_uses_lwt

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["test/*.test.ts", "test/unit/**/*.test.ts"],
+    include: ["test/integration-test/**/*.test.ts"],
+    testTimeout: 180_000,
+    hookTimeout: 60_000,
   },
 });


### PR DESCRIPTION
## Summary
- add a separate Vitest integration-test config and `test:integration` script
- add Java-style real-cluster integration tests under `test/integration-test`
- add Java-style Docker/Makefile CI harness that starts a three-node ScyllaDB cluster and runs integration tests during PR CI
- keep public live-node APIs to snapshots/refreshes and drop the public `nextNode()` helper
- add `test/COVERAGE_GAPS.md` mapping Java unit/integration coverage to JS coverage and listing Java-only features intentionally not ported
- document integration-test environment variables and `make test-all` in the README

## Covered Areas
- real-cluster Alternator discovery and live-node APIs: cluster, datacenter, rack, wrong-scope fallback, rack/datacenter support checks, live-node snapshots/refreshes, and command routing through discovered nodes
- DynamoDB operations through the load-balanced client: low-level CRUD, document-client CRUD, and multi-node write/read consistency
- key-route affinity: `DescribeTable` partition-key autodiscovery, post-discovery same-key routing, preconfigured partition-key metadata, and no extra `DescribeTable` when metadata is preconfigured
- request compression: enabled-client behavior, large payload gzip, small request no-compression, and compression combined with header optimization and TLS
- header optimization: disabled-by-default wire headers, required auth headers, configured allowlists, custom allowlisted headers, and compression headers preserved under optimization
- HTTP/request handling and pooling: delegated custom `requestHandler`, bounded Node socket pools, serial requests, parallel requests, idle gaps, repeated live-node refreshes, and SDK operations with header optimization enabled
- TLS: HTTPS with certificate validation disabled, optional custom CA, custom-CA CRUD, TLS combined with routing/compression/header optimization, and TLS session cache default/enabled/disabled behavior
- Java parity accounting: coverage matrix for Java integration/unit areas already covered in JS and Java-only surfaces intentionally not ported

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run verify`: typecheck, lint, 7 unit test files / 29 tests, build
- `make test-all`: starts three-node ScyllaDB Docker cluster and runs enabled integration suite, 8 integration test files / 52 tests
