### PR TITLE
Add Alternator user-agent reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ new AlternatorDynamoDBClient({
     allowedHeaders: ["Host", "X-Amz-Target", "Content-Length", "Accept-Encoding", "Content-Encoding"],
   },
 
+  userAgent: (userAgent) => `${userAgent} my-app/1.2.3`,
+
   keyRouteAffinity: {
     type: "any-write",
     partitionKeys: {
@@ -188,7 +190,36 @@ Header optimization is disabled by default. When enabled, headers are
 whitelisted, not removed by a strip list. The default
 whitelist is `Host`, `X-Amz-Target`, `Content-Length`, `Accept-Encoding`, and
 `Content-Encoding`; when credentials are configured, `Authorization` and
-`X-Amz-Date` are also kept.
+`X-Amz-Date` are also kept. The Alternator `User-Agent` is applied after this
+filter, so it is kept unless `userAgent: false` is configured.
+
+By default, the client replaces the AWS SDK `User-Agent` with the ScyllaDB
+Alternator client identity:
+
+```text
+scylladb-alternator-client-javascript/<version>
+```
+
+You can replace it completely:
+
+```ts
+new AlternatorDynamoDBClient({
+  seeds: ["scylla-0.internal"],
+  userAgent: "my-client/1.2.3",
+});
+```
+
+You can transform the generated value. The function receives the default
+ScyllaDB Alternator user-agent:
+
+```ts
+new AlternatorDynamoDBClient({
+  seeds: ["scylla-0.internal"],
+  userAgent: (userAgent) => `${userAgent} my-app/4.5.6`,
+});
+```
+
+Use `userAgent: false` to remove the header entirely.
 
 Request compression is disabled by default. When enabled, it compresses every
 request body with gzip. Use `gzipLevel` to select the zlib level, or provide

--- a/src/client.ts
+++ b/src/client.ts
@@ -119,6 +119,7 @@ function buildDynamoConfig(
     runtime: _runtime,
     compression: _compression,
     headerOptimization: _headerOptimization,
+    userAgent: _userAgent,
     keyRouteAffinity: _keyRouteAffinity,
     tls: _tls,
     discovery: _discovery,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 import { routing } from "./routing.js";
 import { normalizeLogger } from "./logger.js";
+import { normalizeUserAgent } from "./user-agent.js";
 import type {
   AlternatorConnectionOptions,
   AlternatorDynamoDBClientConfig,
@@ -45,6 +46,7 @@ export function normalizeConfig(input: AlternatorDynamoDBClientConfig): Normaliz
   const noAuth = input.credentials === undefined;
   const compression = normalizeCompression(input.compression);
   const headerOptimization = normalizeHeaderOptimization(input.headerOptimization, noAuth);
+  const userAgent = normalizeUserAgent(input.userAgent);
   const keyRouteAffinity = normalizeKeyRouteAffinity(input.keyRouteAffinity);
   const discovery = normalizeDiscovery(input.discovery, runtime);
   const connection = input.connection ? normalizeConnection(input.connection) : undefined;
@@ -57,6 +59,7 @@ export function normalizeConfig(input: AlternatorDynamoDBClientConfig): Normaliz
     runtime,
     compression,
     headerOptimization,
+    userAgent,
     keyRouteAffinity,
     discovery,
     ...(input.tls ? { tls: input.tls } : {}),

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,9 @@ export type {
   AlternatorRequestCompressor,
   AlternatorRequestCompressorResult,
   AlternatorTlsOptions,
+  AlternatorUserAgentConfig,
+  AlternatorUserAgentOptions,
+  AlternatorUserAgentTransformer,
 } from "./types.js";
 export type {
   ClusterRoutingRule,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,7 @@ import type { AlternatorDiscovery } from "./discovery.js";
 import type { KeyRouteAffinityPlanner } from "./affinity.js";
 import type { AlternatorQueryPlan } from "./query-plan.js";
 import type { NormalizedAlternatorConfig } from "./types.js";
+import { applyUserAgent } from "./user-agent.js";
 
 const queryPlanKey = "__alternatorQueryPlan";
 
@@ -77,6 +78,8 @@ export function createAlternatorPostSigningMiddleware<Input extends object, Outp
         "x-amz-security-token",
       ]);
     }
+
+    request.headers = applyUserAgent(request.headers, config.userAgent);
 
     return next({
       ...args,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import type { RoutingRule } from "./routing.js";
 export type AlternatorScheme = "http" | "https";
 export type AlternatorRuntime = "node" | "edge";
 export type AlternatorKeyRouteAffinityType = "none" | "read-before-write" | "any-write";
+export type AlternatorUserAgentTransformer = (userAgent: string) => string | null | undefined;
 
 export interface AlternatorLogger {
   debug?: (...content: unknown[]) => void;
@@ -45,6 +46,18 @@ export interface AlternatorHeaderOptimizationOptions {
    */
   stripHeaders?: readonly string[];
 }
+
+export interface AlternatorUserAgentOptions {
+  enabled?: boolean;
+  value?: string;
+  transform?: AlternatorUserAgentTransformer;
+}
+
+export type AlternatorUserAgentConfig =
+  | boolean
+  | string
+  | AlternatorUserAgentTransformer
+  | AlternatorUserAgentOptions;
 
 export type AlternatorPartitionKeyByTable = Record<string, string>;
 
@@ -100,6 +113,7 @@ export interface AlternatorDynamoDBClientConfig extends BaseDynamoDBClientConfig
   requestHandler?: DynamoDBClientConfig["requestHandler"];
   compression?: boolean | AlternatorCompressionOptions;
   headerOptimization?: boolean | AlternatorHeaderOptimizationOptions;
+  userAgent?: AlternatorUserAgentConfig;
   keyRouteAffinity?: boolean | AlternatorKeyRouteAffinityOptions;
   tls?: AlternatorTlsOptions;
   discovery?: AlternatorDiscoveryOptions;
@@ -117,6 +131,10 @@ export interface NormalizedCompressionOptions {
 export interface NormalizedHeaderOptimizationOptions {
   readonly enabled: boolean;
   readonly allowedHeaders: readonly string[];
+}
+
+export interface NormalizedUserAgentOptions {
+  readonly value?: string;
 }
 
 export interface NormalizedKeyRouteAffinityOptions {
@@ -141,6 +159,7 @@ export interface NormalizedAlternatorConfig {
   readonly runtime: AlternatorRuntime;
   readonly compression: NormalizedCompressionOptions;
   readonly headerOptimization: NormalizedHeaderOptimizationOptions;
+  readonly userAgent: NormalizedUserAgentOptions;
   readonly keyRouteAffinity: NormalizedKeyRouteAffinityOptions;
   readonly discovery: NormalizedDiscoveryOptions;
   readonly tls?: AlternatorTlsOptions;

--- a/src/user-agent.ts
+++ b/src/user-agent.ts
@@ -1,0 +1,89 @@
+import packageJson from "../package.json" with { type: "json" };
+import type {
+  AlternatorUserAgentConfig,
+  AlternatorUserAgentTransformer,
+  NormalizedUserAgentOptions,
+} from "./types.js";
+
+export const ALTERNATOR_USER_AGENT_PRODUCT = "scylladb-alternator-client-javascript";
+
+export function alternatorUserAgentToken(): string {
+  return `${ALTERNATOR_USER_AGENT_PRODUCT}/${normalizeVersion(packageJson.version)}`;
+}
+
+export function normalizeUserAgent(input: AlternatorUserAgentConfig | undefined): NormalizedUserAgentOptions {
+  const defaultUserAgent = alternatorUserAgentToken();
+
+  if (input === false) {
+    return {};
+  }
+  if (input === undefined || input === true) {
+    return { value: defaultUserAgent };
+  }
+  if (typeof input === "string") {
+    requireValidUserAgent(input, "userAgent");
+    return { value: input };
+  }
+  if (typeof input === "function") {
+    return normalizeTransformedUserAgent(input, defaultUserAgent);
+  }
+  if (input.enabled === false) {
+    return {};
+  }
+  if (input.value !== undefined && input.transform !== undefined) {
+    throw new TypeError("userAgent.value and userAgent.transform cannot both be set");
+  }
+  if (input.value !== undefined) {
+    requireValidUserAgent(input.value, "userAgent.value");
+    return { value: input.value };
+  }
+  if (input.transform !== undefined) {
+    return normalizeTransformedUserAgent(input.transform, defaultUserAgent);
+  }
+  return { value: defaultUserAgent };
+}
+
+export function applyUserAgent(
+  headers: Record<string, string | undefined>,
+  userAgent: NormalizedUserAgentOptions,
+): Record<string, string> {
+  const nextHeaders: Record<string, string> = {};
+
+  for (const [name, value] of Object.entries(headers)) {
+    if (value === undefined || name.toLowerCase() === "user-agent") {
+      continue;
+    }
+    nextHeaders[name] = value;
+  }
+
+  if (userAgent.value !== undefined) {
+    nextHeaders["user-agent"] = userAgent.value;
+  }
+
+  return nextHeaders;
+}
+
+function normalizeTransformedUserAgent(
+  transform: AlternatorUserAgentTransformer,
+  defaultUserAgent: string,
+): NormalizedUserAgentOptions {
+  const transformed = transform(defaultUserAgent);
+  if (transformed === null || transformed === undefined || transformed.trim() === "") {
+    return {};
+  }
+  return { value: transformed };
+}
+
+function requireValidUserAgent(userAgent: string, label: string): void {
+  if (userAgent.trim() === "") {
+    throw new TypeError(`${label} cannot be blank`);
+  }
+}
+
+function normalizeVersion(version: string | undefined): string {
+  const trimmed = version?.trim();
+  if (!trimmed) {
+    return "unknown";
+  }
+  return trimmed.replace(/\s+/g, "_");
+}

--- a/test/COVERAGE_GAPS.md
+++ b/test/COVERAGE_GAPS.md
@@ -37,6 +37,7 @@ integration tests:
 - Config validation for seeds, scheme, port, runtime, connection options, headers, compression, and TLS.
 - `/localnodes` discovery, rack/datacenter query fallback, request-triggered edge discovery, and live-node access.
 - Alternator middleware request rewriting, retry node selection, no-auth header stripping, SigV4 preservation, header whitelisting, and gzip request compression.
+- User-agent replacement, customization, transform, removal, and preservation with header optimization.
 - Query-plan ordering, seeded random ordering, and retry distribution behavior.
 - Murmur3 and AttributeValue hash vectors shared with the Java tests.
 - Key-route affinity classification for write and read-before-write operations.
@@ -63,4 +64,3 @@ feature surface:
 - Exact TCP socket-count assertions using `ss` filtered by JVM PID. The JS suite covers the
   equivalent externally visible behavior: repeated discovery refreshes, serial requests, parallel
   requests, idle gaps, and bounded socket-pool configuration.
-- Java user-agent wrapper classes. The JS package does not add a separate user-agent HTTP wrapper.

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -63,4 +63,25 @@ describe("AlternatorDynamoDBClient config", () => {
         }),
     ).toThrow(/socket pool/);
   });
+
+  it("validates User-Agent options", () => {
+    expect(
+      () =>
+        new AlternatorDynamoDBClient({
+          seeds: ["localhost"],
+          userAgent: "",
+        }),
+    ).toThrow(/userAgent/);
+
+    expect(
+      () =>
+        new AlternatorDynamoDBClient({
+          seeds: ["localhost"],
+          userAgent: {
+            value: "custom/1",
+            transform: (userAgent) => `${userAgent} app/1`,
+          },
+        }),
+    ).toThrow(/cannot both be set/);
+  });
 });

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -2,6 +2,7 @@ import { ListTablesCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
 import { gunzipSync } from "node:zlib";
 import { describe, expect, it, vi } from "vitest";
 import { AlternatorDynamoDBClient } from "../src/index.js";
+import { alternatorUserAgentToken } from "../src/user-agent.js";
 import { commandRequests, jsonResponse, RecordingHandler } from "./helpers.js";
 
 describe("Alternator middleware", () => {
@@ -149,6 +150,73 @@ describe("Alternator middleware", () => {
     expect(headers["x-amz-date"]).toBeUndefined();
     expect(headers["content-type"]).toBeUndefined();
     expect(headers.connection).toBeUndefined();
+  });
+
+  it("replaces the SDK User-Agent with the Alternator client identity by default", async () => {
+    const handler = new RecordingHandler(() => ({ TableNames: [] }));
+    const client = new AlternatorDynamoDBClient({
+      seeds: ["seed"],
+      requestHandler: handler,
+      discovery: { background: false },
+      customUserAgent: "app/1",
+    });
+
+    await client.send(new ListTablesCommand({}));
+
+    const headers = commandRequests(handler)[0]?.headers ?? {};
+    expect(headers["user-agent"]).toBe(alternatorUserAgentToken());
+    expect(headers["user-agent"]).not.toContain("app/1");
+  });
+
+  it("supports replacing, transforming, and removing the Alternator User-Agent", async () => {
+    const replacements = new RecordingHandler(() => ({ TableNames: [] }));
+    const transformed = new RecordingHandler(() => ({ TableNames: [] }));
+    const removed = new RecordingHandler(() => ({ TableNames: [] }));
+
+    const replacementClient = new AlternatorDynamoDBClient({
+      seeds: ["seed"],
+      requestHandler: replacements,
+      discovery: { background: false },
+      userAgent: "custom-client/1.2.3",
+    });
+    const transformedClient = new AlternatorDynamoDBClient({
+      seeds: ["seed"],
+      requestHandler: transformed,
+      discovery: { background: false },
+      userAgent: (userAgent) => `${userAgent} app/4.5.6`,
+    });
+    const removedClient = new AlternatorDynamoDBClient({
+      seeds: ["seed"],
+      requestHandler: removed,
+      discovery: { background: false },
+      userAgent: false,
+    });
+
+    await replacementClient.send(new ListTablesCommand({}));
+    await transformedClient.send(new ListTablesCommand({}));
+    await removedClient.send(new ListTablesCommand({}));
+
+    expect(commandRequests(replacements)[0]?.headers["user-agent"]).toBe("custom-client/1.2.3");
+    expect(commandRequests(transformed)[0]?.headers["user-agent"]).toBe(
+      `${alternatorUserAgentToken()} app/4.5.6`,
+    );
+    expect(commandRequests(removed)[0]?.headers["user-agent"]).toBeUndefined();
+  });
+
+  it("keeps the generated User-Agent when header optimization is enabled", async () => {
+    const handler = new RecordingHandler(() => ({ TableNames: [] }));
+    const client = new AlternatorDynamoDBClient({
+      seeds: ["seed"],
+      requestHandler: handler,
+      discovery: { background: false },
+      headerOptimization: true,
+    });
+
+    await client.send(new ListTablesCommand({}));
+
+    const headers = commandRequests(handler)[0]?.headers ?? {};
+    expect(headers["user-agent"]).toBe(alternatorUserAgentToken());
+    expect(headers["content-type"]).toBeUndefined();
   });
 
   it("routes matching keys to the same node when key affinity is enabled", async () => {

--- a/test/type-usage.test.ts
+++ b/test/type-usage.test.ts
@@ -25,6 +25,7 @@ describe("public type usage", () => {
         enabled: true,
         gzipLevel: -1,
       },
+      userAgent: (userAgent) => `${userAgent} app/1.0.0`,
       keyRouteAffinity: {
         type: "read-before-write",
         partitionKeys: {


### PR DESCRIPTION
Closes #15

## Summary
- Add Alternator user-agent normalization and final request rewriting with the default `scylladb-alternator-client-javascript/<version>` token.
- Support exact replacement, transform callbacks, and disabling the `User-Agent` header.
- Apply user-agent rewriting after signing/header filtering and document the public option.

## Verification
- npm run verify
- npm pack --dry-run