### PR TITLE
Fix cluster-wide Alternator discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,20 @@ Routing helpers:
 
 ```ts
 routing.cluster();
+routing.cluster({ datacenters: ["dc1", "dc2"] });
 routing.datacenter("dc1", { fallback: routing.cluster() });
 routing.rack("dc1", "rack1", {
-  fallback: routing.datacenter("dc1", { fallback: routing.cluster() }),
+  fallback: routing.datacenter("dc1", {
+    fallback: routing.cluster({ datacenters: ["dc1", "dc2"] }),
+  }),
 });
 ```
+
+`routing.cluster()` queries `/localnodes` on every configured seed or already
+known live node and unions the returned local-node lists. In multi-datacenter
+deployments, configure at least one seed per datacenter, or pass known
+datacenter names with `routing.cluster({ datacenters: [...] })` so discovery can
+ask `/localnodes?dc=<name>` for each datacenter.
 
 ## Runtime Matrix
 

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -2,7 +2,7 @@ import { HttpRequest } from "@smithy/protocol-http";
 import type { HttpHandlerOptions } from "@smithy/types";
 import { bodyToString } from "./body.js";
 import { hostForUrl, nodeUrl } from "./config.js";
-import { routingChain, routingQueries, type LocalNodesQuery, type RoutingRule } from "./routing.js";
+import { routingChain, type ClusterRoutingRule, type LocalNodesQuery, type RoutingRule } from "./routing.js";
 import { AlternatorQueryPlan } from "./query-plan.js";
 import type { AlternatorNode, NormalizedAlternatorConfig } from "./types.js";
 
@@ -82,12 +82,21 @@ export class AlternatorDiscovery {
 
     for (const rule of routingChain(this.config.routing)) {
       if (rule.kind === "cluster") {
-        return;
+        if (!rule.datacenters) {
+          return;
+        }
+
+        const missing = await this.missingClusterDatacenters(rule);
+        if (missing.length === 0) {
+          return;
+        }
+        errors.push(`scope ${routingRuleLabel(rule)} has no nodes in datacenter(s): ${missing.join(", ")}`);
+        continue;
       }
 
       const query = queryForRoutingRule(rule);
       try {
-        const nodes = await this.fetchFirstSuccessfulLocalNodes(query);
+        const nodes = await this.fetchFirstAvailableLocalNodes(query);
         if (nodes.length > 0) {
           return;
         }
@@ -111,26 +120,22 @@ export class AlternatorDiscovery {
   }
 
   private async refreshLiveNodesOnce(): Promise<AlternatorNode[]> {
-    const queries = routingQueries(this.config.routing);
     const candidates = this.candidateHosts();
 
-    for (const query of queries) {
-      for (const host of candidates) {
-        try {
-          const nodes = await this.fetchLocalNodes(host, query);
-          if (nodes.length > 0) {
-            this.liveHosts = normalizeDiscoveredHosts(nodes);
-            return this.getLiveNodes();
-          }
-          this.config.logger.debug?.("alternator discovery: localnodes returned no nodes", { host, query });
-        } catch (error) {
-          this.config.logger.debug?.("alternator discovery: localnodes request failed", {
-            host,
-            query,
-            error,
-          });
-          continue;
+    for (const rule of routingChain(this.config.routing)) {
+      try {
+        const nodes = rule.kind === "cluster"
+          ? await this.fetchClusterLocalNodes(rule, candidates)
+          : await this.fetchFirstAvailableLocalNodes(queryForRoutingRule(rule), candidates);
+        if (nodes.length > 0) {
+          this.liveHosts = normalizeDiscoveredHosts(nodes);
+          return this.getLiveNodes();
         }
+      } catch (error) {
+        this.config.logger.debug?.("alternator discovery: localnodes request failed", {
+          rule: routingRuleLabel(rule),
+          error,
+        });
       }
     }
 
@@ -141,11 +146,67 @@ export class AlternatorDiscovery {
     return [...new Set([...this.liveHosts, ...this.config.seeds])];
   }
 
-  private async fetchFirstSuccessfulLocalNodes(query: LocalNodesQuery): Promise<string[]> {
-    let lastError: unknown;
-    for (const host of this.candidateHosts()) {
+  private async missingClusterDatacenters(rule: ClusterRoutingRule): Promise<string[]> {
+    const missing: string[] = [];
+    for (const dc of rule.datacenters ?? []) {
       try {
-        return await this.fetchLocalNodes(host, query);
+        const nodes = await this.fetchFirstAvailableLocalNodes({ dc });
+        if (nodes.length === 0) {
+          missing.push(dc);
+        }
+      } catch (error) {
+        throw new Error(`failed to read list of nodes for datacenter ${dc}: ${errorMessage(error)}`);
+      }
+    }
+    return missing;
+  }
+
+  private async fetchClusterLocalNodes(
+    rule: ClusterRoutingRule,
+    candidates: readonly string[] = this.candidateHosts(),
+  ): Promise<string[]> {
+    const nodes: string[] = [];
+    const queries = clusterQueries(rule);
+
+    for (const query of queries) {
+      for (const host of candidates) {
+        try {
+          const discovered = await this.fetchLocalNodes(host, query);
+          if (discovered.length > 0) {
+            nodes.push(...discovered);
+            if (query.dc) {
+              break;
+            }
+          } else {
+            this.config.logger.debug?.("alternator discovery: localnodes returned no nodes", { host, query });
+          }
+        } catch (error) {
+          this.config.logger.debug?.("alternator discovery: localnodes request failed", {
+            host,
+            query,
+            error,
+          });
+        }
+      }
+    }
+
+    return normalizeDiscoveredHosts(nodes);
+  }
+
+  private async fetchFirstAvailableLocalNodes(
+    query: LocalNodesQuery,
+    candidates: readonly string[] = this.candidateHosts(),
+  ): Promise<string[]> {
+    let lastError: unknown;
+    let sawEmptyResponse = false;
+    for (const host of candidates) {
+      try {
+        const nodes = await this.fetchLocalNodes(host, query);
+        if (nodes.length > 0) {
+          return nodes;
+        }
+        sawEmptyResponse = true;
+        this.config.logger.debug?.("alternator discovery: localnodes returned no nodes", { host, query });
       } catch (error) {
         lastError = error;
         this.config.logger.debug?.("alternator discovery: localnodes request failed", {
@@ -154,6 +215,9 @@ export class AlternatorDiscovery {
           error,
         });
       }
+    }
+    if (sawEmptyResponse) {
+      return [];
     }
     if (lastError instanceof Error) {
       throw lastError;
@@ -210,6 +274,10 @@ function queryToRequestQuery(query: LocalNodesQuery): Record<string, string> {
   return result;
 }
 
+function clusterQueries(rule: ClusterRoutingRule): LocalNodesQuery[] {
+  return rule.datacenters?.map((dc) => ({ dc })) ?? [{}];
+}
+
 function normalizeDiscoveredHosts(hosts: readonly string[]): string[] {
   return [...new Set(hosts.map((host) => host.trim()).filter(Boolean))];
 }
@@ -232,6 +300,9 @@ function queryForRoutingRule(rule: RoutingRule): LocalNodesQuery {
 function routingRuleLabel(rule: RoutingRule): string {
   switch (rule.kind) {
     case "cluster":
+      if (rule.datacenters) {
+        return `Cluster(datacenters=${rule.datacenters.join(",")})`;
+      }
       return "Cluster()";
     case "datacenter":
       return `Datacenter(dc=${rule.datacenter})`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export type {
   AlternatorUserAgentTransformer,
 } from "./types.js";
 export type {
+  ClusterRoutingOptions,
   ClusterRoutingRule,
   DatacenterRoutingRule,
   RackRoutingRule,

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -4,8 +4,13 @@ export interface RoutingFallbackOptions {
   fallback?: RoutingRule;
 }
 
+export interface ClusterRoutingOptions {
+  datacenters?: readonly string[];
+}
+
 export interface ClusterRoutingRule {
   readonly kind: "cluster";
+  readonly datacenters?: readonly string[];
 }
 
 export interface DatacenterRoutingRule {
@@ -28,14 +33,38 @@ export interface LocalNodesQuery {
   readonly rack?: string;
 }
 
-function assertName(name: string, label: string): void {
+function assertName(name: unknown, label: string): asserts name is string {
   if (typeof name !== "string" || name.trim() === "") {
     throw new TypeError(`${label} must be a non-empty string`);
   }
 }
 
-function cluster(): ClusterRoutingRule {
-  return { kind: "cluster" };
+function normalizeNames(names: readonly string[] | undefined, label: string): string[] | undefined {
+  if (names === undefined) {
+    return undefined;
+  }
+  const values: unknown = names;
+  if (!Array.isArray(values)) {
+    throw new TypeError(`${label}s must be an array`);
+  }
+
+  const rawNames: readonly unknown[] = values;
+  const normalized = [...new Set(rawNames.map((name) => {
+    assertName(name, label);
+    return name.trim();
+  }))];
+  if (normalized.length === 0) {
+    throw new TypeError(`${label}s must contain at least one ${label}`);
+  }
+  return normalized;
+}
+
+function cluster(options: ClusterRoutingOptions = {}): ClusterRoutingRule {
+  const datacenters = normalizeNames(options.datacenters, "datacenter");
+  return {
+    kind: "cluster",
+    ...(datacenters ? { datacenters } : {}),
+  };
 }
 
 function datacenter(datacenterName: string, options: RoutingFallbackOptions = {}): DatacenterRoutingRule {
@@ -69,9 +98,9 @@ export const routing = {
 };
 
 export function routingQueries(rule: RoutingRule): LocalNodesQuery[] {
-  const query = queryForRule(rule);
+  const queries = queriesForRule(rule);
   const fallback = "fallback" in rule ? rule.fallback : undefined;
-  return fallback ? [query, ...routingQueries(fallback)] : [query];
+  return fallback ? [...queries, ...routingQueries(fallback)] : queries;
 }
 
 export function routingChain(rule: RoutingRule): RoutingRule[] {
@@ -79,13 +108,13 @@ export function routingChain(rule: RoutingRule): RoutingRule[] {
   return fallback ? [rule, ...routingChain(fallback)] : [rule];
 }
 
-function queryForRule(rule: RoutingRule): LocalNodesQuery {
+function queriesForRule(rule: RoutingRule): LocalNodesQuery[] {
   switch (rule.kind) {
     case "cluster":
-      return {};
+      return rule.datacenters?.map((dc) => ({ dc })) ?? [{}];
     case "datacenter":
-      return { dc: rule.datacenter };
+      return [{ dc: rule.datacenter }];
     case "rack":
-      return { dc: rule.datacenter, rack: rule.rack };
+      return [{ dc: rule.datacenter, rack: rule.rack }];
   }
 }

--- a/test/discovery.test.ts
+++ b/test/discovery.test.ts
@@ -37,6 +37,62 @@ describe("Alternator discovery", () => {
     ]);
   });
 
+  it("unions cluster discovery across configured seeds", async () => {
+    const handler = new RecordingHandler((request) => {
+      if (request.path !== "/localnodes") {
+        return {};
+      }
+      if (request.hostname === "seed-dc1.internal") {
+        return ["dc1-a.internal", "dc1-b.internal"];
+      }
+      if (request.hostname === "seed-dc2.internal") {
+        return ["dc2-a.internal", "dc2-b.internal"];
+      }
+      return [];
+    });
+    const client = new AlternatorDynamoDBClient({
+      seeds: ["seed-dc1.internal", "seed-dc2.internal"],
+      requestHandler: handler,
+      discovery: { background: false },
+      routing: routing.cluster(),
+    });
+
+    await client.refreshLiveNodes();
+
+    expect(client.getLiveNodes().map((node) => node.host)).toEqual([
+      "dc1-a.internal",
+      "dc1-b.internal",
+      "dc2-a.internal",
+      "dc2-b.internal",
+    ]);
+    expect(handler.requests.map((request) => request.query)).toEqual([{}, {}]);
+  });
+
+  it("queries named datacenters for cluster discovery", async () => {
+    const seenQueries: Array<Record<string, unknown>> = [];
+    const handler = new RecordingHandler((request) => {
+      seenQueries.push(request.query);
+      if (request.query.dc === "dc1") {
+        return ["dc1-node"];
+      }
+      if (request.query.dc === "dc2") {
+        return ["dc2-node"];
+      }
+      return [];
+    });
+    const client = new AlternatorDynamoDBClient({
+      seeds: ["seed"],
+      requestHandler: handler,
+      discovery: { background: false },
+      routing: routing.cluster({ datacenters: ["dc1", "dc2"] }),
+    });
+
+    await client.refreshLiveNodes();
+
+    expect(seenQueries).toEqual([{ dc: "dc1" }, { dc: "dc2" }]);
+    expect(client.getLiveNodes().map((node) => node.host)).toEqual(["dc1-node", "dc2-node"]);
+  });
+
   it("tries rack/datacenter routing fallback in order", async () => {
     const seenQueries: Array<Record<string, unknown>> = [];
     const handler = new RecordingHandler((request) => {
@@ -99,6 +155,19 @@ describe("Alternator discovery", () => {
     });
     await expect(valid.checkIfRackAndDatacenterSetCorrectly()).resolves.toBeUndefined();
 
+    const validCluster = new AlternatorDynamoDBClient({
+      seeds: ["seed"],
+      requestHandler: new RecordingHandler((request) => {
+        if (request.query.dc === "dc1") {
+          return ["dc-node"];
+        }
+        return [];
+      }),
+      discovery: { background: false },
+      routing: routing.cluster({ datacenters: ["dc1"] }),
+    });
+    await expect(validCluster.checkIfRackAndDatacenterSetCorrectly()).resolves.toBeUndefined();
+
     const invalid = new AlternatorDynamoDBClient({
       seeds: ["seed"],
       requestHandler: new RecordingHandler(() => []),
@@ -108,6 +177,14 @@ describe("Alternator discovery", () => {
       }),
     });
     await expect(invalid.validateRackDatacenterConfig()).rejects.toThrow(/has no nodes/);
+
+    const invalidCluster = new AlternatorDynamoDBClient({
+      seeds: ["seed"],
+      requestHandler: new RecordingHandler(() => []),
+      discovery: { background: false },
+      routing: routing.cluster({ datacenters: ["dc1"] }),
+    });
+    await expect(invalidCluster.validateRackDatacenterConfig()).rejects.toThrow(/datacenter\(s\): dc1/);
   });
 
   it("uses request-triggered discovery in edge runtime", async () => {

--- a/test/type-usage.test.ts
+++ b/test/type-usage.test.ts
@@ -13,7 +13,9 @@ describe("public type usage", () => {
   it("accepts native AWS SDK v3 commands", () => {
     const client = new AlternatorDynamoDBClient({
       seeds: ["localhost"],
-      routing: routing.datacenter("dc1", { fallback: routing.cluster() }),
+      routing: routing.rack("dc1", "rack1", {
+        fallback: routing.cluster({ datacenters: ["dc1", "dc2"] }),
+      }),
       requestHandler: new RecordingHandler(),
       discovery: { background: false },
       logger: console,


### PR DESCRIPTION
Closes #30

## Summary
- Make cluster routing aggregate `/localnodes` results instead of treating the first response as the whole cluster.
- Add `routing.cluster({ datacenters: [...] })` so users can discover known datacenters with `/localnodes?dc=<name>`.
- Validate named cluster datacenters and document multi-datacenter seed/discovery behavior.

## Verification
- npm test -- --run test/discovery.test.ts test/type-usage.test.ts
- npm run typecheck
- npm run verify