### PR TITLE
Use configured seeds for cluster-wide discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,20 +103,15 @@ Routing helpers:
 
 ```ts
 routing.cluster();
-routing.cluster({ datacenters: ["dc1", "dc2"] });
 routing.datacenter("dc1", { fallback: routing.cluster() });
 routing.rack("dc1", "rack1", {
-  fallback: routing.datacenter("dc1", {
-    fallback: routing.cluster({ datacenters: ["dc1", "dc2"] }),
-  }),
+  fallback: routing.datacenter("dc1", { fallback: routing.cluster() }),
 });
 ```
 
-`routing.cluster()` queries `/localnodes` on every configured seed or already
-known live node and unions the returned local-node lists. In multi-datacenter
-deployments, configure at least one seed per datacenter, or pass known
-datacenter names with `routing.cluster({ datacenters: [...] })` so discovery can
-ask `/localnodes?dc=<name>` for each datacenter.
+`routing.cluster()` queries `/localnodes` on every configured seed and unions
+the returned local-node lists. In multi-datacenter deployments, configure at
+least one seed per datacenter.
 
 ## Runtime Matrix
 

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -2,7 +2,7 @@ import { HttpRequest } from "@smithy/protocol-http";
 import type { HttpHandlerOptions } from "@smithy/types";
 import { bodyToString } from "./body.js";
 import { hostForUrl, nodeUrl } from "./config.js";
-import { routingChain, type ClusterRoutingRule, type LocalNodesQuery, type RoutingRule } from "./routing.js";
+import { routingChain, type LocalNodesQuery, type RoutingRule } from "./routing.js";
 import { AlternatorQueryPlan } from "./query-plan.js";
 import type { AlternatorNode, NormalizedAlternatorConfig } from "./types.js";
 
@@ -82,16 +82,7 @@ export class AlternatorDiscovery {
 
     for (const rule of routingChain(this.config.routing)) {
       if (rule.kind === "cluster") {
-        if (!rule.datacenters) {
-          return;
-        }
-
-        const missing = await this.missingClusterDatacenters(rule);
-        if (missing.length === 0) {
-          return;
-        }
-        errors.push(`scope ${routingRuleLabel(rule)} has no nodes in datacenter(s): ${missing.join(", ")}`);
-        continue;
+        return;
       }
 
       const query = queryForRoutingRule(rule);
@@ -125,7 +116,7 @@ export class AlternatorDiscovery {
     for (const rule of routingChain(this.config.routing)) {
       try {
         const nodes = rule.kind === "cluster"
-          ? await this.fetchClusterLocalNodes(rule, candidates)
+          ? await this.fetchClusterLocalNodes()
           : await this.fetchFirstAvailableLocalNodes(queryForRoutingRule(rule), candidates);
         if (nodes.length > 0) {
           this.liveHosts = normalizeDiscoveredHosts(nodes);
@@ -146,47 +137,24 @@ export class AlternatorDiscovery {
     return [...new Set([...this.liveHosts, ...this.config.seeds])];
   }
 
-  private async missingClusterDatacenters(rule: ClusterRoutingRule): Promise<string[]> {
-    const missing: string[] = [];
-    for (const dc of rule.datacenters ?? []) {
+  private async fetchClusterLocalNodes(): Promise<string[]> {
+    const nodes: string[] = [];
+    const query: LocalNodesQuery = {};
+
+    for (const host of this.config.seeds) {
       try {
-        const nodes = await this.fetchFirstAvailableLocalNodes({ dc });
-        if (nodes.length === 0) {
-          missing.push(dc);
+        const discovered = await this.fetchLocalNodes(host, query);
+        if (discovered.length > 0) {
+          nodes.push(...discovered);
+        } else {
+          this.config.logger.debug?.("alternator discovery: localnodes returned no nodes", { host, query });
         }
       } catch (error) {
-        throw new Error(`failed to read list of nodes for datacenter ${dc}: ${errorMessage(error)}`);
-      }
-    }
-    return missing;
-  }
-
-  private async fetchClusterLocalNodes(
-    rule: ClusterRoutingRule,
-    candidates: readonly string[] = this.candidateHosts(),
-  ): Promise<string[]> {
-    const nodes: string[] = [];
-    const queries = clusterQueries(rule);
-
-    for (const query of queries) {
-      for (const host of candidates) {
-        try {
-          const discovered = await this.fetchLocalNodes(host, query);
-          if (discovered.length > 0) {
-            nodes.push(...discovered);
-            if (query.dc) {
-              break;
-            }
-          } else {
-            this.config.logger.debug?.("alternator discovery: localnodes returned no nodes", { host, query });
-          }
-        } catch (error) {
-          this.config.logger.debug?.("alternator discovery: localnodes request failed", {
-            host,
-            query,
-            error,
-          });
-        }
+        this.config.logger.debug?.("alternator discovery: localnodes request failed", {
+          host,
+          query,
+          error,
+        });
       }
     }
 
@@ -274,10 +242,6 @@ function queryToRequestQuery(query: LocalNodesQuery): Record<string, string> {
   return result;
 }
 
-function clusterQueries(rule: ClusterRoutingRule): LocalNodesQuery[] {
-  return rule.datacenters?.map((dc) => ({ dc })) ?? [{}];
-}
-
 function normalizeDiscoveredHosts(hosts: readonly string[]): string[] {
   return [...new Set(hosts.map((host) => host.trim()).filter(Boolean))];
 }
@@ -300,9 +264,6 @@ function queryForRoutingRule(rule: RoutingRule): LocalNodesQuery {
 function routingRuleLabel(rule: RoutingRule): string {
   switch (rule.kind) {
     case "cluster":
-      if (rule.datacenters) {
-        return `Cluster(datacenters=${rule.datacenters.join(",")})`;
-      }
       return "Cluster()";
     case "datacenter":
       return `Datacenter(dc=${rule.datacenter})`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ export type {
   AlternatorUserAgentTransformer,
 } from "./types.js";
 export type {
-  ClusterRoutingOptions,
   ClusterRoutingRule,
   DatacenterRoutingRule,
   RackRoutingRule,

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -4,13 +4,8 @@ export interface RoutingFallbackOptions {
   fallback?: RoutingRule;
 }
 
-export interface ClusterRoutingOptions {
-  datacenters?: readonly string[];
-}
-
 export interface ClusterRoutingRule {
   readonly kind: "cluster";
-  readonly datacenters?: readonly string[];
 }
 
 export interface DatacenterRoutingRule {
@@ -33,38 +28,14 @@ export interface LocalNodesQuery {
   readonly rack?: string;
 }
 
-function assertName(name: unknown, label: string): asserts name is string {
+function assertName(name: string, label: string): void {
   if (typeof name !== "string" || name.trim() === "") {
     throw new TypeError(`${label} must be a non-empty string`);
   }
 }
 
-function normalizeNames(names: readonly string[] | undefined, label: string): string[] | undefined {
-  if (names === undefined) {
-    return undefined;
-  }
-  const values: unknown = names;
-  if (!Array.isArray(values)) {
-    throw new TypeError(`${label}s must be an array`);
-  }
-
-  const rawNames: readonly unknown[] = values;
-  const normalized = [...new Set(rawNames.map((name) => {
-    assertName(name, label);
-    return name.trim();
-  }))];
-  if (normalized.length === 0) {
-    throw new TypeError(`${label}s must contain at least one ${label}`);
-  }
-  return normalized;
-}
-
-function cluster(options: ClusterRoutingOptions = {}): ClusterRoutingRule {
-  const datacenters = normalizeNames(options.datacenters, "datacenter");
-  return {
-    kind: "cluster",
-    ...(datacenters ? { datacenters } : {}),
-  };
+function cluster(): ClusterRoutingRule {
+  return { kind: "cluster" };
 }
 
 function datacenter(datacenterName: string, options: RoutingFallbackOptions = {}): DatacenterRoutingRule {
@@ -98,9 +69,9 @@ export const routing = {
 };
 
 export function routingQueries(rule: RoutingRule): LocalNodesQuery[] {
-  const queries = queriesForRule(rule);
+  const query = queryForRule(rule);
   const fallback = "fallback" in rule ? rule.fallback : undefined;
-  return fallback ? [...queries, ...routingQueries(fallback)] : queries;
+  return fallback ? [query, ...routingQueries(fallback)] : [query];
 }
 
 export function routingChain(rule: RoutingRule): RoutingRule[] {
@@ -108,13 +79,13 @@ export function routingChain(rule: RoutingRule): RoutingRule[] {
   return fallback ? [rule, ...routingChain(fallback)] : [rule];
 }
 
-function queriesForRule(rule: RoutingRule): LocalNodesQuery[] {
+function queryForRule(rule: RoutingRule): LocalNodesQuery {
   switch (rule.kind) {
     case "cluster":
-      return rule.datacenters?.map((dc) => ({ dc })) ?? [{}];
+      return {};
     case "datacenter":
-      return [{ dc: rule.datacenter }];
+      return { dc: rule.datacenter };
     case "rack":
-      return [{ dc: rule.datacenter, rack: rule.rack }];
+      return { dc: rule.datacenter, rack: rule.rack };
   }
 }

--- a/test/discovery.test.ts
+++ b/test/discovery.test.ts
@@ -65,32 +65,15 @@ describe("Alternator discovery", () => {
       "dc2-a.internal",
       "dc2-b.internal",
     ]);
-    expect(handler.requests.map((request) => request.query)).toEqual([{}, {}]);
-  });
-
-  it("queries named datacenters for cluster discovery", async () => {
-    const seenQueries: Array<Record<string, unknown>> = [];
-    const handler = new RecordingHandler((request) => {
-      seenQueries.push(request.query);
-      if (request.query.dc === "dc1") {
-        return ["dc1-node"];
-      }
-      if (request.query.dc === "dc2") {
-        return ["dc2-node"];
-      }
-      return [];
-    });
-    const client = new AlternatorDynamoDBClient({
-      seeds: ["seed"],
-      requestHandler: handler,
-      discovery: { background: false },
-      routing: routing.cluster({ datacenters: ["dc1", "dc2"] }),
-    });
-
     await client.refreshLiveNodes();
 
-    expect(seenQueries).toEqual([{ dc: "dc1" }, { dc: "dc2" }]);
-    expect(client.getLiveNodes().map((node) => node.host)).toEqual(["dc1-node", "dc2-node"]);
+    expect(handler.requests.map((request) => request.hostname)).toEqual([
+      "seed-dc1.internal",
+      "seed-dc2.internal",
+      "seed-dc1.internal",
+      "seed-dc2.internal",
+    ]);
+    expect(handler.requests.map((request) => request.query)).toEqual([{}, {}, {}, {}]);
   });
 
   it("tries rack/datacenter routing fallback in order", async () => {
@@ -155,19 +138,6 @@ describe("Alternator discovery", () => {
     });
     await expect(valid.checkIfRackAndDatacenterSetCorrectly()).resolves.toBeUndefined();
 
-    const validCluster = new AlternatorDynamoDBClient({
-      seeds: ["seed"],
-      requestHandler: new RecordingHandler((request) => {
-        if (request.query.dc === "dc1") {
-          return ["dc-node"];
-        }
-        return [];
-      }),
-      discovery: { background: false },
-      routing: routing.cluster({ datacenters: ["dc1"] }),
-    });
-    await expect(validCluster.checkIfRackAndDatacenterSetCorrectly()).resolves.toBeUndefined();
-
     const invalid = new AlternatorDynamoDBClient({
       seeds: ["seed"],
       requestHandler: new RecordingHandler(() => []),
@@ -177,14 +147,6 @@ describe("Alternator discovery", () => {
       }),
     });
     await expect(invalid.validateRackDatacenterConfig()).rejects.toThrow(/has no nodes/);
-
-    const invalidCluster = new AlternatorDynamoDBClient({
-      seeds: ["seed"],
-      requestHandler: new RecordingHandler(() => []),
-      discovery: { background: false },
-      routing: routing.cluster({ datacenters: ["dc1"] }),
-    });
-    await expect(invalidCluster.validateRackDatacenterConfig()).rejects.toThrow(/datacenter\(s\): dc1/);
   });
 
   it("uses request-triggered discovery in edge runtime", async () => {

--- a/test/type-usage.test.ts
+++ b/test/type-usage.test.ts
@@ -14,7 +14,7 @@ describe("public type usage", () => {
     const client = new AlternatorDynamoDBClient({
       seeds: ["localhost"],
       routing: routing.rack("dc1", "rack1", {
-        fallback: routing.cluster({ datacenters: ["dc1", "dc2"] }),
+        fallback: routing.cluster(),
       }),
       requestHandler: new RecordingHandler(),
       discovery: { background: false },


### PR DESCRIPTION
Follow-up to #31.

## Summary
- Keep cluster-wide discovery based on bare `/localnodes` requests to the configured seeds only.
- Remove the extra `routing.cluster({ datacenters })` API from the previous solution.
- Document the expected multi-datacenter setup: provide at least one seed per datacenter.

## Verification
- npm test -- --run test/discovery.test.ts test/type-usage.test.ts
- npm run typecheck
- npm run verify