### PR TITLE
Keep optimized header whitelist Go-compatible

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -130,13 +130,16 @@ function buildDynamoConfig(
     ...awsConfig
   } = input;
 
-  const dynamoConfig: DynamoDBClientConfig = {
+  const dynamoConfig: DynamoDBClientConfig & { applyChecksum?: boolean } = {
     ...awsConfig,
     endpoint: firstEndpointUrl(alternatorConfig),
     region: region ?? DEFAULT_REGION,
     credentials: credentials ?? NO_AUTH_CREDENTIALS,
     requestHandler,
   };
+  if (alternatorConfig.headerOptimization.enabled) {
+    dynamoConfig.applyChecksum = false;
+  }
   return dynamoConfig;
 }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -69,7 +69,7 @@ export function createAlternatorPostSigningMiddleware<Input extends object, Outp
     const request = HttpRequest.clone(args.request);
 
     if (config.headerOptimization.enabled) {
-      request.headers = whitelistHeaders(request.headers, config.headerOptimization.allowedHeaders);
+      request.headers = whitelistHeaders(request.headers, optimizedAllowedHeaders(request.headers, config));
     } else if (config.noAuth) {
       request.headers = removeHeaders(request.headers, [
         "authorization",
@@ -86,6 +86,21 @@ export function createAlternatorPostSigningMiddleware<Input extends object, Outp
       request,
     });
   };
+}
+
+function optimizedAllowedHeaders(
+  headers: Record<string, string | undefined>,
+  config: NormalizedAlternatorConfig,
+): readonly string[] {
+  if (config.noAuth) {
+    return config.headerOptimization.allowedHeaders;
+  }
+
+  return [
+    ...config.headerOptimization.allowedHeaders,
+    "authorization",
+    ...signedHeaderNames(headers),
+  ];
 }
 
 function getOrCreateQueryPlan<Input extends object>(
@@ -122,6 +137,26 @@ function whitelistHeaders(
   }
 
   return nextHeaders;
+}
+
+function signedHeaderNames(headers: Record<string, string | undefined>): string[] {
+  const authorization = headerValue(headers, "authorization");
+  if (!authorization) {
+    return [];
+  }
+
+  const match = /(?:^|,\s*)SignedHeaders=([^,\s]+)/.exec(authorization);
+  return match?.[1]?.split(";").filter(Boolean) ?? [];
+}
+
+function headerValue(headers: Record<string, string | undefined>, name: string): string | undefined {
+  const target = name.toLowerCase();
+  for (const [headerName, value] of Object.entries(headers)) {
+    if (headerName.toLowerCase() === target) {
+      return value;
+    }
+  }
+  return undefined;
 }
 
 function removeHeaders(

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -51,6 +51,10 @@ export function createAlternatorRequestMiddleware<Input extends object, Output e
       request = await maybeCompressRequest(request, config);
     }
 
+    if (config.headerOptimization.enabled) {
+      request.headers = whitelistHeaders(request.headers, config.headerOptimization.allowedHeaders);
+    }
+
     return next({
       ...args,
       request,
@@ -69,7 +73,7 @@ export function createAlternatorPostSigningMiddleware<Input extends object, Outp
     const request = HttpRequest.clone(args.request);
 
     if (config.headerOptimization.enabled) {
-      request.headers = whitelistHeaders(request.headers, optimizedAllowedHeaders(request.headers, config));
+      request.headers = whitelistHeaders(request.headers, config.headerOptimization.allowedHeaders);
     } else if (config.noAuth) {
       request.headers = removeHeaders(request.headers, [
         "authorization",
@@ -86,21 +90,6 @@ export function createAlternatorPostSigningMiddleware<Input extends object, Outp
       request,
     });
   };
-}
-
-function optimizedAllowedHeaders(
-  headers: Record<string, string | undefined>,
-  config: NormalizedAlternatorConfig,
-): readonly string[] {
-  if (config.noAuth) {
-    return config.headerOptimization.allowedHeaders;
-  }
-
-  return [
-    ...config.headerOptimization.allowedHeaders,
-    "authorization",
-    ...signedHeaderNames(headers),
-  ];
 }
 
 function getOrCreateQueryPlan<Input extends object>(
@@ -137,26 +126,6 @@ function whitelistHeaders(
   }
 
   return nextHeaders;
-}
-
-function signedHeaderNames(headers: Record<string, string | undefined>): string[] {
-  const authorization = headerValue(headers, "authorization");
-  if (!authorization) {
-    return [];
-  }
-
-  const match = /(?:^|,\s*)SignedHeaders=([^,\s]+)/.exec(authorization);
-  return match?.[1]?.split(";").filter(Boolean) ?? [];
-}
-
-function headerValue(headers: Record<string, string | undefined>, name: string): string | undefined {
-  const target = name.toLowerCase();
-  for (const [headerName, value] of Object.entries(headers)) {
-    if (headerName.toLowerCase() === target) {
-      return value;
-    }
-  }
-  return undefined;
 }
 
 function removeHeaders(

--- a/test/integration-test/alternator-client.test.ts
+++ b/test/integration-test/alternator-client.test.ts
@@ -181,8 +181,7 @@ describeIntegration.each(integrationEndpoints())(
         expect(headers["x-amz-target"]).toBe("DynamoDB_20120810.ListTables");
         expect(headers.authorization).toContain("AWS4-HMAC-SHA256");
         expect(headers["x-amz-date"]).toBeDefined();
-        expect(headers["content-type"]).toBeUndefined();
-        expect(headers["x-amz-content-sha256"]).toBeUndefined();
+        expectSignedHeadersPresent(headers);
       } finally {
         client.destroy();
       }
@@ -232,7 +231,7 @@ describeIntegration.each(integrationEndpoints())(
         expect(headers.authorization).toContain("AWS4-HMAC-SHA256");
         expect(headers["x-amz-date"]).toBeDefined();
         expect(headers["content-type"]).toBe("application/x-amz-json-1.0");
-        expect(headers["x-amz-content-sha256"]).toBeUndefined();
+        expectSignedHeadersPresent(headers);
       } finally {
         client.destroy();
       }
@@ -275,7 +274,7 @@ describeIntegration.each(integrationEndpoints())(
         const headers = commandHeaders(captured, "PutItemCommand");
         expect(headers["content-encoding"]).toBe("gzip");
         expect(headers["content-length"]).toBeDefined();
-        expect(headers["content-type"]).toBeUndefined();
+        expectSignedHeadersPresent(headers);
       } finally {
         client.destroy();
       }
@@ -288,3 +287,14 @@ describe("integration test opt-in", () => {
     expect(typeof integrationConfig.enabled).toBe("boolean");
   });
 });
+
+function expectSignedHeadersPresent(headers: Record<string, string | undefined>): void {
+  for (const name of signedHeaderNames(headers.authorization)) {
+    expect(headers[name]).toBeDefined();
+  }
+}
+
+function signedHeaderNames(authorization: string | undefined): string[] {
+  const match = authorization?.match(/(?:^|,\s*)SignedHeaders=([^,\s]+)/);
+  return match?.[1]?.split(";").filter(Boolean) ?? [];
+}

--- a/test/integration-test/alternator-client.test.ts
+++ b/test/integration-test/alternator-client.test.ts
@@ -181,6 +181,12 @@ describeIntegration.each(integrationEndpoints())(
         expect(headers["x-amz-target"]).toBe("DynamoDB_20120810.ListTables");
         expect(headers.authorization).toContain("AWS4-HMAC-SHA256");
         expect(headers["x-amz-date"]).toBeDefined();
+        expect(headers["content-type"]).toBeUndefined();
+        expect(headers["content-length"]).toBeUndefined();
+        expect(headers["x-amz-content-sha256"]).toBeUndefined();
+        expect(headers["x-amz-user-agent"]).toBeUndefined();
+        expect(headers["amz-sdk-invocation-id"]).toBeUndefined();
+        expect(headers["amz-sdk-request"]).toBeUndefined();
         expectSignedHeadersPresent(headers);
       } finally {
         client.destroy();
@@ -231,6 +237,10 @@ describeIntegration.each(integrationEndpoints())(
         expect(headers.authorization).toContain("AWS4-HMAC-SHA256");
         expect(headers["x-amz-date"]).toBeDefined();
         expect(headers["content-type"]).toBe("application/x-amz-json-1.0");
+        expect(headers["x-amz-content-sha256"]).toBeUndefined();
+        expect(headers["x-amz-user-agent"]).toBeUndefined();
+        expect(headers["amz-sdk-invocation-id"]).toBeUndefined();
+        expect(headers["amz-sdk-request"]).toBeUndefined();
         expectSignedHeadersPresent(headers);
       } finally {
         client.destroy();
@@ -274,6 +284,11 @@ describeIntegration.each(integrationEndpoints())(
         const headers = commandHeaders(captured, "PutItemCommand");
         expect(headers["content-encoding"]).toBe("gzip");
         expect(headers["content-length"]).toBeDefined();
+        expect(headers["content-type"]).toBeUndefined();
+        expect(headers["x-amz-content-sha256"]).toBeUndefined();
+        expect(headers["x-amz-user-agent"]).toBeUndefined();
+        expect(headers["amz-sdk-invocation-id"]).toBeUndefined();
+        expect(headers["amz-sdk-request"]).toBeUndefined();
         expectSignedHeadersPresent(headers);
       } finally {
         client.destroy();

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -83,7 +83,7 @@ describe("Alternator middleware", () => {
     expect(request?.headers.authorization).toContain("Credential=key/");
   });
 
-  it("keeps whitelist auth headers when credentials and header optimization are enabled", async () => {
+  it("keeps SigV4 signed headers when credentials and header optimization are enabled", async () => {
     const handler = new RecordingHandler(() => ({ TableNames: [] }));
     const client = new AlternatorDynamoDBClient({
       seeds: ["seed"],
@@ -101,8 +101,10 @@ describe("Alternator middleware", () => {
     const headers = commandRequests(handler)[0]?.headers ?? {};
     expect(headers.authorization).toContain("AWS4-HMAC-SHA256");
     expect(headers["x-amz-date"]).toBeDefined();
-    expect(headers["x-amz-content-sha256"]).toBeUndefined();
-    expect(headers["content-type"]).toBeUndefined();
+
+    for (const name of signedHeaderNames(headers.authorization)) {
+      expect(headers[name]).toBeDefined();
+    }
   });
 
   it("compresses JSON request bodies when enabled", async () => {
@@ -257,3 +259,8 @@ describe("Alternator middleware", () => {
     expect(client.getPartitionKeyName("users")).toBe("id");
   });
 });
+
+function signedHeaderNames(authorization: string | undefined): string[] {
+  const match = authorization?.match(/(?:^|,\s*)SignedHeaders=([^,\s]+)/);
+  return match?.[1]?.split(";").filter(Boolean) ?? [];
+}

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -83,7 +83,7 @@ describe("Alternator middleware", () => {
     expect(request?.headers.authorization).toContain("Credential=key/");
   });
 
-  it("keeps SigV4 signed headers when credentials and header optimization are enabled", async () => {
+  it("uses the Go-compatible optimized header whitelist with credentials", async () => {
     const handler = new RecordingHandler(() => ({ TableNames: [] }));
     const client = new AlternatorDynamoDBClient({
       seeds: ["seed"],
@@ -101,10 +101,21 @@ describe("Alternator middleware", () => {
     const headers = commandRequests(handler)[0]?.headers ?? {};
     expect(headers.authorization).toContain("AWS4-HMAC-SHA256");
     expect(headers["x-amz-date"]).toBeDefined();
-
-    for (const name of signedHeaderNames(headers.authorization)) {
-      expect(headers[name]).toBeDefined();
-    }
+    expect(headers["x-amz-target"]).toBe("DynamoDB_20120810.ListTables");
+    expect(headers["content-length"]).toBeDefined();
+    expect(headers.host).toBe("seed:8080");
+    expect(headers["user-agent"]).toBe(alternatorUserAgentToken());
+    expect(headers["content-type"]).toBeUndefined();
+    expect(headers["x-amz-content-sha256"]).toBeUndefined();
+    expect(headers["x-amz-user-agent"]).toBeUndefined();
+    expect(headers["amz-sdk-invocation-id"]).toBeUndefined();
+    expect(headers["amz-sdk-request"]).toBeUndefined();
+    expect(signedHeaderNames(headers.authorization)).toEqual([
+      "content-length",
+      "host",
+      "x-amz-date",
+      "x-amz-target",
+    ]);
   });
 
   it("compresses JSON request bodies when enabled", async () => {


### PR DESCRIPTION
## Summary

- Apply header optimization before signing and after signing so SigV4 only signs headers that can survive the configured whitelist.
- Keep the default optimized wire header set aligned with the Go client instead of expanding it with every JS SDK signed header.
- Disable signer-generated checksum headers while optimization is enabled and tighten regression assertions for stripped SDK bookkeeping headers.

Closes #33

## Verification

- `npm run verify`
- `npm run test:integration` (live integration tests skipped because `INTEGRATION_TESTS` was not set)