### PR TITLE
Reuse query plans after retry exhaustion

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,7 +5,7 @@ import { hostForUrl } from "./config.js";
 import type { AlternatorDiscovery } from "./discovery.js";
 import type { KeyRouteAffinityPlanner } from "./affinity.js";
 import type { AlternatorQueryPlan } from "./query-plan.js";
-import type { NormalizedAlternatorConfig } from "./types.js";
+import type { AlternatorNode, NormalizedAlternatorConfig } from "./types.js";
 import { applyUserAgent } from "./user-agent.js";
 
 const queryPlanKey = "__alternatorQueryPlan";
@@ -28,8 +28,7 @@ export function createAlternatorRequestMiddleware<Input extends object, Output e
 
     await discovery.refreshIfDue();
 
-    const plan = getOrCreateQueryPlan(context, args.input, discovery, keyAffinity);
-    const node = plan.next();
+    const node = nextNodeForAttempt(context, args.input, discovery, keyAffinity);
     if (!node) {
       throw new Error("Alternator query plan exhausted");
     }
@@ -92,23 +91,37 @@ export function createAlternatorPostSigningMiddleware<Input extends object, Outp
   };
 }
 
-function getOrCreateQueryPlan<Input extends object>(
+function nextNodeForAttempt<Input extends object>(
   context: HandlerExecutionContext,
   input: Input,
   discovery: AlternatorDiscovery,
   keyAffinity: KeyRouteAffinityPlanner,
-): AlternatorQueryPlan {
+): AlternatorNode | undefined {
   const contextRecord = context as HandlerExecutionContext & {
     [queryPlanKey]?: AlternatorQueryPlan;
   };
 
   if (!contextRecord[queryPlanKey]) {
-    const nodes = discovery.getLiveNodes();
-    contextRecord[queryPlanKey] =
-      keyAffinity.queryPlanForInput(input, nodes, context.commandName) ?? discovery.createQueryPlan();
+    contextRecord[queryPlanKey] = createQueryPlan(context, input, discovery, keyAffinity);
   }
 
-  return contextRecord[queryPlanKey];
+  const node = contextRecord[queryPlanKey].next();
+  if (node) {
+    return node;
+  }
+
+  contextRecord[queryPlanKey] = createQueryPlan(context, input, discovery, keyAffinity);
+  return contextRecord[queryPlanKey].next();
+}
+
+function createQueryPlan<Input extends object>(
+  context: HandlerExecutionContext,
+  input: Input,
+  discovery: AlternatorDiscovery,
+  keyAffinity: KeyRouteAffinityPlanner,
+): AlternatorQueryPlan {
+  const nodes = discovery.getLiveNodes();
+  return keyAffinity.queryPlanForInput(input, nodes, context.commandName) ?? discovery.createQueryPlan();
 }
 
 function whitelistHeaders(

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -64,6 +64,36 @@ describe("Alternator middleware", () => {
     expect(second?.hostname).toBe("node-b");
   });
 
+  it("continues retrying when maxAttempts exceeds the live node count", async () => {
+    let commandAttempts = 0;
+    const handler = new RecordingHandler((request) => {
+      if (request.path === "/localnodes") {
+        return ["node-a"];
+      }
+      commandAttempts += 1;
+      if (commandAttempts < 3) {
+        return jsonResponse({ __type: "InternalServerError", message: "retry" }, 500);
+      }
+      return { TableNames: [] };
+    });
+    const client = new AlternatorDynamoDBClient({
+      seeds: ["seed"],
+      requestHandler: handler,
+      discovery: { background: false },
+      maxAttempts: 3,
+    });
+
+    await client.refreshLiveNodes();
+    await client.send(new ListTablesCommand({}));
+
+    expect(commandAttempts).toBe(3);
+    expect(commandRequests(handler).map((request) => request.hostname)).toEqual([
+      "node-a",
+      "node-a",
+      "node-a",
+    ]);
+  });
+
   it("keeps SigV4 signing when credentials are provided", async () => {
     const handler = new RecordingHandler(() => ({ TableNames: [] }));
     const client = new AlternatorDynamoDBClient({


### PR DESCRIPTION
## Summary

- Rebuild the per-command query plan when the current plan has no remaining nodes.
- Preserve first-pass node diversity while allowing SDK retries to continue when `maxAttempts` exceeds the live node count.
- Add a regression covering one live node with `maxAttempts: 3`.

Closes #34

## Verification

- `npm run verify`