### PR TITLE
Destroy owned document client resources

### DIFF
--- a/src/document.ts
+++ b/src/document.ts
@@ -12,13 +12,17 @@ type InternalDocumentClientConstructor = new (
 ) => AlternatorDynamoDBDocumentClient;
 
 export class AlternatorDynamoDBDocumentClient extends DynamoDBDocumentClient {
+  private readonly ownedClient: AlternatorDynamoDBClient | undefined;
+
   constructor(config: AlternatorDynamoDBClientConfig, translateConfig?: TranslateConfig);
   constructor(configOrClient: AlternatorDynamoDBClientConfig | DynamoDBClient, translateConfig?: TranslateConfig) {
+    let ownedClient: AlternatorDynamoDBClient | undefined;
     const client =
       configOrClient instanceof DynamoDBClient
         ? configOrClient
-        : new AlternatorDynamoDBClient(configOrClient);
+        : (ownedClient = new AlternatorDynamoDBClient(configOrClient));
     super(client, translateConfig);
+    this.ownedClient = ownedClient;
   }
 
   static override from(
@@ -28,6 +32,11 @@ export class AlternatorDynamoDBDocumentClient extends DynamoDBDocumentClient {
     const InternalDocumentClient =
       AlternatorDynamoDBDocumentClient as unknown as InternalDocumentClientConstructor;
     return new InternalDocumentClient(client, translateConfig);
+  }
+
+  override destroy(): void {
+    this.ownedClient?.destroy();
+    super.destroy();
   }
 }
 

--- a/test/document.test.ts
+++ b/test/document.test.ts
@@ -1,6 +1,6 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { PutCommand } from "@aws-sdk/lib-dynamodb";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AlternatorDynamoDBClient } from "../src/client.js";
 import { AlternatorDynamoDBDocumentClient } from "../src/document.js";
 import { commandRequests, RecordingHandler, requestBodyJson } from "./helpers.js";
@@ -82,5 +82,39 @@ describe("AlternatorDynamoDBDocumentClient", () => {
 
     expect(commandRequests(handler)[0]?.hostname).toBe("aws-style.local");
     expect("getLiveNodes" in docClient).toBe(false);
+  });
+
+  it("destroys the owned low-level client and stops background discovery", async () => {
+    vi.useFakeTimers();
+    const handler = new RecordingHandler((request) => {
+      if (request.path === "/localnodes") {
+        return ["seed"];
+      }
+      return {};
+    });
+    const docClient = new AlternatorDynamoDBDocumentClient({
+      seeds: ["seed"],
+      requestHandler: handler,
+      discovery: {
+        background: true,
+        refreshIntervalMs: 10,
+      },
+    });
+
+    try {
+      await vi.advanceTimersByTimeAsync(25);
+      const callsBeforeDestroy = handler.requests.filter((request) => request.path === "/localnodes").length;
+      expect(callsBeforeDestroy).toBeGreaterThan(0);
+
+      docClient.destroy();
+      expect(handler.destroyCalls).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(25);
+      const callsAfterDestroy = handler.requests.filter((request) => request.path === "/localnodes").length;
+      expect(callsAfterDestroy).toBe(callsBeforeDestroy);
+    } finally {
+      docClient.destroy();
+      vi.useRealTimers();
+    }
   });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -10,6 +10,7 @@ export type HandlerResponder = (
 export class RecordingHandler {
   readonly metadata = { handlerProtocol: "http/1.1" };
   readonly requests: HttpRequest[] = [];
+  destroyCalls = 0;
 
   constructor(private readonly responder: HandlerResponder = () => ({})) {}
 
@@ -34,6 +35,10 @@ export class RecordingHandler {
 
   httpHandlerConfigs(): Record<string, never> {
     return {};
+  }
+
+  destroy(): void {
+    this.destroyCalls += 1;
   }
 }
 


### PR DESCRIPTION
## Summary

- Track the low-level Alternator client created by config-based document-client construction.
- Destroy that owned low-level client when the document client is destroyed.
- Add a regression proving background discovery stops and the owned request handler is destroyed.

Closes #35

## Verification

- `npm run verify`