### PR TITLE
Validate runtime config values

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -43,7 +43,7 @@ export function normalizeConfig(input: AlternatorDynamoDBClientConfig): Normaliz
   assertPort(port);
 
   const seeds = normalizeSeeds(input.seeds);
-  const runtime = input.runtime ?? detectRuntime();
+  const runtime = normalizeRuntime(input.runtime);
   const noAuth = input.credentials === undefined;
   const routingRule = normalizeRouting(input.routing);
   const compression = normalizeCompression(input.compression);
@@ -177,6 +177,14 @@ function normalizeRoutingFallback(
     return {};
   }
   return { fallback: normalizeRoutingRule(fallback, `${label}.fallback`) };
+}
+
+function normalizeRuntime(runtime: AlternatorDynamoDBClientConfig["runtime"]): AlternatorRuntime {
+  const normalized = runtime ?? detectRuntime();
+  if (normalized !== "node" && normalized !== "edge") {
+    throw new TypeError('runtime must be either "node" or "edge"');
+  }
+  return normalized;
 }
 
 function normalizeCompression(input: AlternatorDynamoDBClientConfig["compression"]) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -49,6 +49,14 @@ describe("AlternatorDynamoDBClient config", () => {
       () =>
         new AlternatorDynamoDBClient({
           seeds: ["localhost"],
+          runtime: "worker" as never,
+        }),
+    ).toThrow(/runtime/);
+
+    expect(
+      () =>
+        new AlternatorDynamoDBClient({
+          seeds: ["localhost"],
           runtime: "edge",
           tls: { caFile: "/tmp/ca.pem" },
         }),


### PR DESCRIPTION
## Summary

- Normalize `runtime` through an explicit allowed-value check.
- Reject unsupported runtime values instead of letting them fall through to the node/default path.
- Add a config regression for an invalid runtime supplied from JavaScript/casts.

Closes #38

## Verification

- `npm run verify`