### PR TITLE
Reject bracketed IPv6 seeds with ports

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -122,8 +122,18 @@ function normalizeSeed(seed: string): string {
   if (trimmed.includes("://") || /[/?#]/.test(trimmed)) {
     throw new TypeError(`seed "${seed}" must be a host, not a URL`);
   }
-  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+  if (trimmed.startsWith("[")) {
+    const bracketEnd = trimmed.indexOf("]");
+    if (bracketEnd < 0) {
+      throw new TypeError(`seed "${seed}" must be a valid IPv6 host`);
+    }
+    if (bracketEnd !== trimmed.length - 1) {
+      throw new TypeError(`seed "${seed}" must not include a port; use the port option`);
+    }
     return trimmed.slice(1, -1);
+  }
+  if (trimmed.includes("]")) {
+    throw new TypeError(`seed "${seed}" must be a valid IPv6 host`);
   }
 
   const colonCount = [...trimmed].filter((char) => char === ":").length;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -18,8 +18,12 @@ describe("AlternatorDynamoDBClient config", () => {
   it("validates seed host, scheme, and port", () => {
     expect(() => new AlternatorDynamoDBClient({ seeds: ["http://localhost"] })).toThrow(/not a URL/);
     expect(() => new AlternatorDynamoDBClient({ seeds: ["localhost:8000"] })).toThrow(/must not include a port/);
+    expect(() => new AlternatorDynamoDBClient({ seeds: ["[::1]:8080"] })).toThrow(/must not include a port/);
+    expect(() => new AlternatorDynamoDBClient({ seeds: ["::1]"] })).toThrow(/valid IPv6/);
     expect(() => new AlternatorDynamoDBClient({ seeds: ["localhost"], scheme: "ftp" as never })).toThrow(/scheme/);
     expect(() => new AlternatorDynamoDBClient({ seeds: ["localhost"], port: 0 })).toThrow(/port/);
+
+    expect(new AlternatorDynamoDBClient({ seeds: ["[::1]"] }).getLiveNodes()[0]?.url).toBe("http://[::1]:8080");
   });
 
   it("uses Alternator defaults for URL and signing region", async () => {


### PR DESCRIPTION
## Summary

- Reject bracketed IPv6 seed values that include a port suffix.
- Reject malformed bracket usage instead of producing invalid URLs later.
- Add config coverage for bracketed IPv6 acceptance and host:port rejection.

Closes #39

## Verification

- `npm run verify`