### PR TITLE
Validate gzip level against zlib range

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -197,8 +197,8 @@ function normalizeCompression(input: AlternatorDynamoDBClientConfig["compression
     ...(input?.gzipLevel !== undefined ? { gzipLevel: input.gzipLevel } : {}),
     ...(input?.compressor ? { compressor: input.compressor } : {}),
   };
-  if (normalized.gzipLevel !== undefined && (normalized.gzipLevel < -2 || normalized.gzipLevel > 9)) {
-    throw new TypeError("compression.gzipLevel must be between -2 and 9");
+  if (normalized.gzipLevel !== undefined && (normalized.gzipLevel < -1 || normalized.gzipLevel > 9)) {
+    throw new TypeError("compression.gzipLevel must be between -1 and 9");
   }
   return normalized;
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -166,4 +166,27 @@ describe("AlternatorDynamoDBClient config", () => {
         }),
     ).toThrow(/routing\.fallback\.rack/);
   });
+
+  it("validates gzip compression level against zlib range", () => {
+    expect(
+      () =>
+        new AlternatorDynamoDBClient({
+          seeds: ["localhost"],
+          compression: {
+            enabled: true,
+            gzipLevel: -2,
+          },
+        }),
+    ).toThrow(/gzipLevel/);
+
+    expect(
+      new AlternatorDynamoDBClient({
+        seeds: ["localhost"],
+        compression: {
+          enabled: true,
+          gzipLevel: -1,
+        },
+      }).alternatorConfig.compression.gzipLevel,
+    ).toBe(-1);
+  });
 });


### PR DESCRIPTION
## Summary

- Reject `compression.gzipLevel` values below zlib's supported minimum of `-1`.
- Keep `-1` accepted as zlib's default compression level.
- Add config coverage for the rejected `-2` value.

Closes #40

## Verification

- `npm run verify`