### PR TITLE
Remove SDK user agent for unsigned requests

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -83,7 +83,9 @@ export function createAlternatorPostSigningMiddleware<Input extends object, Outp
       ]);
     }
 
-    request.headers = applyUserAgent(request.headers, config.userAgent);
+    request.headers = applyUserAgent(request.headers, config.userAgent, {
+      removeAwsSdkUserAgent: config.noAuth,
+    });
 
     return next({
       ...args,

--- a/src/user-agent.ts
+++ b/src/user-agent.ts
@@ -46,11 +46,17 @@ export function normalizeUserAgent(input: AlternatorUserAgentConfig | undefined)
 export function applyUserAgent(
   headers: Record<string, string | undefined>,
   userAgent: NormalizedUserAgentOptions,
+  options: { removeAwsSdkUserAgent?: boolean } = {},
 ): Record<string, string> {
   const nextHeaders: Record<string, string> = {};
 
   for (const [name, value] of Object.entries(headers)) {
-    if (value === undefined || name.toLowerCase() === "user-agent") {
+    const normalizedName = name.toLowerCase();
+    if (
+      value === undefined ||
+      normalizedName === "user-agent" ||
+      (options.removeAwsSdkUserAgent && normalizedName === "x-amz-user-agent")
+    ) {
       continue;
     }
     nextHeaders[name] = value;

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -179,6 +179,7 @@ describe("Alternator middleware", () => {
     const headers = commandRequests(handler)[0]?.headers ?? {};
     expect(headers["user-agent"]).toBe(alternatorUserAgentToken());
     expect(headers["user-agent"]).not.toContain("app/1");
+    expect(headers["x-amz-user-agent"]).toBeUndefined();
   });
 
   it("supports replacing, transforming, and removing the Alternator User-Agent", async () => {
@@ -214,6 +215,7 @@ describe("Alternator middleware", () => {
       `${alternatorUserAgentToken()} app/4.5.6`,
     );
     expect(commandRequests(removed)[0]?.headers["user-agent"]).toBeUndefined();
+    expect(commandRequests(removed)[0]?.headers["x-amz-user-agent"]).toBeUndefined();
   });
 
   it("keeps the generated User-Agent when header optimization is enabled", async () => {


### PR DESCRIPTION
## Summary

- Remove `x-amz-user-agent` from no-auth requests when applying Alternator user-agent handling.
- Keep signed requests unchanged so SigV4 `SignedHeaders` are not invalidated.
- Add regressions for default replacement and `userAgent: false` wire headers.

Closes #41

## Verification

- `npm run verify`