### PR TITLE
Reject node agent overrides

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -284,6 +284,9 @@ function normalizeDiscovery(
 }
 
 function normalizeConnection(input: AlternatorConnectionOptions): AlternatorConnectionOptions {
+  if (input.node !== undefined && ("httpAgent" in input.node || "httpsAgent" in input.node)) {
+    throw new TypeError("connection.node cannot include httpAgent or httpsAgent; use Alternator connection and tls options");
+  }
   if (input.maxSockets !== undefined) {
     assertPositive(input.maxSockets, "connection.maxSockets");
   }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -93,6 +93,32 @@ describe("AlternatorDynamoDBClient config", () => {
     ).toThrow(/cannot both be set/);
   });
 
+  it("rejects direct Node agent overrides in connection.node", () => {
+    expect(
+      () =>
+        new AlternatorDynamoDBClient({
+          seeds: ["localhost"],
+          connection: {
+            node: {
+              httpAgent: {},
+            },
+          } as never,
+        }),
+    ).toThrow(/httpAgent or httpsAgent/);
+
+    expect(
+      () =>
+        new AlternatorDynamoDBClient({
+          seeds: ["localhost"],
+          connection: {
+            node: {
+              httpsAgent: {},
+            },
+          } as never,
+        }),
+    ).toThrow(/httpAgent or httpsAgent/);
+  });
+
   it("validates key route affinity partition key mappings", () => {
     expect(
       () =>


### PR DESCRIPTION
## Summary

- Reject `connection.node.httpAgent` and `connection.node.httpsAgent` at runtime.
- Keep internally built agents in control of Alternator TLS, keep-alive, and socket-pool settings.
- Add config coverage for JavaScript/cast-provided agent overrides.

Closes #42

## Verification

- `npm run verify`