### PR TITLE
Validate key route affinity type

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ import type { RoutingRule } from "./routing.js";
 import type {
   AlternatorConnectionOptions,
   AlternatorDynamoDBClientConfig,
+  AlternatorKeyRouteAffinityType,
   AlternatorRuntime,
   NormalizedAlternatorConfig,
 } from "./types.js";
@@ -225,7 +226,7 @@ function normalizeKeyRouteAffinity(input: AlternatorDynamoDBClientConfig["keyRou
       autoDiscoverPartitionKeys: input,
     } as const;
   }
-  const type = input?.type ?? (input?.enabled ? "any-write" : "none");
+  const type = normalizeKeyRouteAffinityType(input?.type ?? (input?.enabled ? "any-write" : "none"));
   return {
     enabled: type !== "none" && input?.enabled !== false,
     type,
@@ -253,6 +254,13 @@ function normalizePartitionKeys(partitionKeys: unknown): Map<string, string> {
     normalized.set(tableName, keyName);
   }
   return normalized;
+}
+
+function normalizeKeyRouteAffinityType(type: unknown): AlternatorKeyRouteAffinityType {
+  if (type === "none" || type === "read-before-write" || type === "any-write") {
+    return type;
+  }
+  throw new TypeError('keyRouteAffinity.type must be "none", "read-before-write", or "any-write"');
 }
 
 function normalizeDiscovery(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -189,4 +189,27 @@ describe("AlternatorDynamoDBClient config", () => {
       }).alternatorConfig.compression.gzipLevel,
     ).toBe(-1);
   });
+
+  it("validates key route affinity type", () => {
+    for (const type of ["bad", "", 42]) {
+      expect(
+        () =>
+          new AlternatorDynamoDBClient({
+            seeds: ["localhost"],
+            keyRouteAffinity: {
+              type,
+            } as never,
+          }),
+      ).toThrow(/keyRouteAffinity\.type/);
+    }
+
+    expect(
+      new AlternatorDynamoDBClient({
+        seeds: ["localhost"],
+        keyRouteAffinity: {
+          type: "read-before-write",
+        },
+      }).alternatorConfig.keyRouteAffinity.type,
+    ).toBe("read-before-write");
+  });
 });


### PR DESCRIPTION
## Summary

- Reject unsupported `keyRouteAffinity.type` values during config normalization.
- Keep the normalized type limited to the documented union.
- Add config coverage for invalid JavaScript/cast values and a valid `read-before-write` value.

Closes #43

## Verification

- `npm run verify`