### PR TITLE
Validate partition key affinity mappings

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -173,9 +173,30 @@ function normalizeKeyRouteAffinity(input: AlternatorDynamoDBClientConfig["keyRou
   return {
     enabled: type !== "none" && input?.enabled !== false,
     type,
-    partitionKeys: new Map(Object.entries(input?.partitionKeys ?? {})),
+    partitionKeys: normalizePartitionKeys(input?.partitionKeys),
     autoDiscoverPartitionKeys: input?.autoDiscoverPartitionKeys ?? type !== "none",
   } as const;
+}
+
+function normalizePartitionKeys(partitionKeys: unknown): Map<string, string> {
+  if (partitionKeys === undefined) {
+    return new Map<string, string>();
+  }
+  if (typeof partitionKeys !== "object" || partitionKeys === null || Array.isArray(partitionKeys)) {
+    throw new TypeError("keyRouteAffinity.partitionKeys must be an object mapping table names to partition keys");
+  }
+
+  const normalized = new Map<string, string>();
+  for (const [tableName, keyName] of Object.entries(partitionKeys)) {
+    if (tableName.trim() === "") {
+      throw new TypeError("keyRouteAffinity.partitionKeys table names must be non-empty strings");
+    }
+    if (typeof keyName !== "string" || keyName.trim() === "") {
+      throw new TypeError("keyRouteAffinity.partitionKeys values must be non-empty strings");
+    }
+    normalized.set(tableName, keyName);
+  }
+  return normalized;
 }
 
 function normalizeDiscovery(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -84,4 +84,40 @@ describe("AlternatorDynamoDBClient config", () => {
         }),
     ).toThrow(/cannot both be set/);
   });
+
+  it("validates key route affinity partition key mappings", () => {
+    expect(
+      () =>
+        new AlternatorDynamoDBClient({
+          seeds: ["localhost"],
+          keyRouteAffinity: {
+            partitionKeys: {
+              users: 123,
+            },
+          } as never,
+        }),
+    ).toThrow(/partitionKeys values/);
+
+    expect(
+      () =>
+        new AlternatorDynamoDBClient({
+          seeds: ["localhost"],
+          keyRouteAffinity: {
+            partitionKeys: {
+              users: "",
+            },
+          },
+        }),
+    ).toThrow(/partitionKeys values/);
+
+    const client = new AlternatorDynamoDBClient({
+      seeds: ["localhost"],
+      keyRouteAffinity: {
+        partitionKeys: {
+          users: "id",
+        },
+      },
+    });
+    expect(client.getPartitionKeyName("users")).toBe("id");
+  });
 });


### PR DESCRIPTION
## Summary

- Validate `keyRouteAffinity.partitionKeys` is an object mapping table names to non-empty string key names.
- Reject non-string and empty partition-key mapping values during config normalization.
- Add config coverage for invalid and valid mappings.

Closes #44

## Verification

- `npm run verify`