### PR TITLE
Handle unsupported localnodes scope filters

### DIFF
--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -10,6 +10,9 @@ interface DiscoveryRequestHandler {
   handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: { statusCode: number; body?: unknown } }>;
 }
 
+type RackDatacenterSupport = "supported" | "unsupported" | "unknown";
+type RackDatacenterProbeKind = "datacenter" | "rack";
+
 export class AlternatorDiscovery {
   private liveHosts: string[];
   private refreshTimer: ReturnType<typeof setInterval> | undefined;
@@ -61,28 +64,44 @@ export class AlternatorDiscovery {
   }
 
   async checkRackDatacenterSupport(): Promise<boolean> {
-    const probe = {
-      dc: "__alternator_client_missing_dc__",
-      rack: "__alternator_client_missing_rack__",
-    };
+    const datacenterSupport = await this.probeRackDatacenterSupport("datacenter");
+    const rackSupport = await this.probeRackDatacenterSupport("rack");
+    return datacenterSupport === "supported" && rackSupport === "supported";
+  }
+
+  private async probeRackDatacenterSupport(kind: RackDatacenterProbeKind): Promise<RackDatacenterSupport> {
+    const probe = missingScopeProbe(kind);
 
     for (const host of this.candidateHosts()) {
       try {
         const nodes = await this.fetchLocalNodes(host, probe);
-        return nodes.length === 0;
+        return nodes.length === 0 ? "supported" : "unsupported";
       } catch {
         continue;
       }
     }
-    return false;
+    return "unknown";
   }
 
   async checkIfRackAndDatacenterSetCorrectly(): Promise<void> {
     const errors: string[] = [];
+    let datacenterSupport: RackDatacenterSupport | undefined;
+    let rackSupport: RackDatacenterSupport | undefined;
 
     for (const rule of routingChain(this.config.routing)) {
       if (rule.kind === "cluster") {
         return;
+      }
+
+      datacenterSupport ??= await this.probeRackDatacenterSupport("datacenter");
+      if (datacenterSupport === "unsupported") {
+        throw new Error("Alternator /localnodes does not support datacenter query parameters");
+      }
+      if (rule.kind === "rack") {
+        rackSupport ??= await this.probeRackDatacenterSupport("rack");
+        if (rackSupport === "unsupported") {
+          throw new Error("Alternator /localnodes does not support rack query parameters");
+        }
       }
 
       const query = queryForRoutingRule(rule);
@@ -112,12 +131,33 @@ export class AlternatorDiscovery {
 
   private async refreshLiveNodesOnce(): Promise<AlternatorNode[]> {
     const candidates = this.candidateHosts();
+    let datacenterSupport: RackDatacenterSupport | undefined;
+    let rackSupport: RackDatacenterSupport | undefined;
 
     for (const rule of routingChain(this.config.routing)) {
       try {
-        const nodes = rule.kind === "cluster"
-          ? await this.fetchClusterLocalNodes()
-          : await this.fetchFirstAvailableLocalNodes(queryForRoutingRule(rule), candidates);
+        let nodes: string[];
+        if (rule.kind === "cluster") {
+          nodes = await this.fetchClusterLocalNodes();
+        } else {
+          datacenterSupport ??= await this.probeRackDatacenterSupport("datacenter");
+          if (datacenterSupport === "unsupported") {
+            this.config.logger.debug?.("alternator discovery: datacenter query parameters are unsupported", {
+              rule: routingRuleLabel(rule),
+            });
+            continue;
+          }
+          if (rule.kind === "rack") {
+            rackSupport ??= await this.probeRackDatacenterSupport("rack");
+            if (rackSupport === "unsupported") {
+              this.config.logger.debug?.("alternator discovery: rack query parameters are unsupported", {
+                rule: routingRuleLabel(rule),
+              });
+              continue;
+            }
+          }
+          nodes = await this.fetchFirstAvailableLocalNodes(queryForRoutingRule(rule), candidates);
+        }
         if (nodes.length > 0) {
           this.liveHosts = normalizeDiscoveredHosts(nodes);
           return this.getLiveNodes();
@@ -240,6 +280,15 @@ function queryToRequestQuery(query: LocalNodesQuery): Record<string, string> {
     result.rack = query.rack;
   }
   return result;
+}
+
+function missingScopeProbe(kind: RackDatacenterProbeKind): LocalNodesQuery {
+  switch (kind) {
+    case "datacenter":
+      return { dc: "__alternator_client_missing_dc__" };
+    case "rack":
+      return { rack: "__alternator_client_missing_rack__" };
+  }
 }
 
 function normalizeDiscoveredHosts(hosts: readonly string[]): string[] {

--- a/test/discovery.test.ts
+++ b/test/discovery.test.ts
@@ -3,6 +3,9 @@ import { AlternatorDynamoDBClient, routing } from "../src/index.js";
 import { RecordingHandler } from "./helpers.js";
 import { ListTablesCommand } from "@aws-sdk/client-dynamodb";
 
+const missingDatacenterQuery = { dc: "__alternator_client_missing_dc__" };
+const missingRackQuery = { rack: "__alternator_client_missing_rack__" };
+
 describe("Alternator discovery", () => {
   it("refreshes live nodes from /localnodes", async () => {
     const handler = new RecordingHandler((request) => {
@@ -80,6 +83,9 @@ describe("Alternator discovery", () => {
     const seenQueries: Array<Record<string, unknown>> = [];
     const handler = new RecordingHandler((request) => {
       seenQueries.push(request.query);
+      if (request.query.dc === missingDatacenterQuery.dc || request.query.rack === missingRackQuery.rack) {
+        return [];
+      }
       if (request.query.rack) {
         return [];
       }
@@ -102,6 +108,8 @@ describe("Alternator discovery", () => {
     await client.refreshLiveNodes();
 
     expect(seenQueries).toEqual([
+      missingDatacenterQuery,
+      missingRackQuery,
       { dc: "dc1", rack: "rack1" },
       { dc: "dc1" },
     ]);
@@ -111,7 +119,7 @@ describe("Alternator discovery", () => {
   it("detects rack/datacenter query support", async () => {
     const supported = new AlternatorDynamoDBClient({
       seeds: ["seed"],
-      requestHandler: new RecordingHandler((request) => (request.query.dc ? [] : ["seed"])),
+      requestHandler: new RecordingHandler((request) => (request.query.dc || request.query.rack ? [] : ["seed"])),
       discovery: { background: false },
     });
     await expect(supported.checkRackDatacenterSupport()).resolves.toBe(true);
@@ -122,6 +130,74 @@ describe("Alternator discovery", () => {
       discovery: { background: false },
     });
     await expect(unsupported.checkRackDatacenterSupport()).resolves.toBe(false);
+  });
+
+  it("falls back instead of accepting scoped nodes when rack/datacenter filters are unsupported", async () => {
+    const seenQueries: Array<Record<string, unknown>> = [];
+    const handler = new RecordingHandler((request) => {
+      seenQueries.push(request.query);
+      if (request.query.dc || request.query.rack) {
+        return ["wrong-scope-node"];
+      }
+      return ["cluster-node"];
+    });
+    const client = new AlternatorDynamoDBClient({
+      seeds: ["seed"],
+      requestHandler: handler,
+      discovery: { background: false },
+      routing: routing.rack("dc1", "rack1", {
+        fallback: routing.datacenter("dc1", {
+          fallback: routing.cluster(),
+        }),
+      }),
+    });
+
+    await client.refreshLiveNodes();
+
+    expect(seenQueries).toEqual([
+      missingDatacenterQuery,
+      {},
+    ]);
+    expect(client.getLiveNodes().map((node) => node.host)).toEqual(["cluster-node"]);
+  });
+
+  it("falls back from rack scope to datacenter scope when only rack filters are unsupported", async () => {
+    const seenQueries: Array<Record<string, unknown>> = [];
+    const handler = new RecordingHandler((request) => {
+      seenQueries.push(request.query);
+      if (request.query.dc === missingDatacenterQuery.dc) {
+        return [];
+      }
+      if (request.query.rack === missingRackQuery.rack) {
+        return ["dc-node"];
+      }
+      if (request.query.rack) {
+        return ["wrong-rack-node"];
+      }
+      if (request.query.dc === "dc1") {
+        return ["dc-node"];
+      }
+      return ["cluster-node"];
+    });
+    const client = new AlternatorDynamoDBClient({
+      seeds: ["seed"],
+      requestHandler: handler,
+      discovery: { background: false },
+      routing: routing.rack("dc1", "rack1", {
+        fallback: routing.datacenter("dc1", {
+          fallback: routing.cluster(),
+        }),
+      }),
+    });
+
+    await client.refreshLiveNodes();
+
+    expect(seenQueries).toEqual([
+      missingDatacenterQuery,
+      missingRackQuery,
+      { dc: "dc1" },
+    ]);
+    expect(client.getLiveNodes().map((node) => node.host)).toEqual(["dc-node"]);
   });
 
   it("validates configured rack/datacenter scopes", async () => {
@@ -147,6 +223,19 @@ describe("Alternator discovery", () => {
       }),
     });
     await expect(invalid.validateRackDatacenterConfig()).rejects.toThrow(/has no nodes/);
+  });
+
+  it("rejects rack/datacenter validation when scope filters are unsupported", async () => {
+    const client = new AlternatorDynamoDBClient({
+      seeds: ["seed"],
+      requestHandler: new RecordingHandler(() => ["seed"]),
+      discovery: { background: false },
+      routing: routing.datacenter("dc1", {
+        fallback: routing.cluster(),
+      }),
+    });
+
+    await expect(client.validateRackDatacenterConfig()).rejects.toThrow(/does not support datacenter/);
   });
 
   it("uses request-triggered discovery in edge runtime", async () => {


### PR DESCRIPTION
## Summary
- probe datacenter and rack /localnodes filter support independently
- skip unsupported scoped routing rules instead of accepting incorrectly scoped nodes
- reject rack/datacenter validation when scope filters are unsupported

## Tests
- npm run verify